### PR TITLE
Feature/instructions starting point

### DIFF
--- a/lib/nes/CMakeLists.txt
+++ b/lib/nes/CMakeLists.txt
@@ -24,6 +24,7 @@ nes_add_library(nes-instructions-lib
 
 #todo: this lib depends on nes-instructions lib, how can we add lib dependencies too? CMAKE optional parameters? named parameters?
 nes_add_library(nes-instruction-decoder-lib
+    src/nes/cpu/instructions/instructionset.cpp
     src/nes/cpu/instructions/instruction_decoder.cpp
 )
 

--- a/lib/nes/CMakeLists.txt
+++ b/lib/nes/CMakeLists.txt
@@ -14,7 +14,16 @@ nes_add_library(nes-peripheral-memory-lib
 )
 
 nes_add_library(nes-bus-lib
-    src/nes/bus/bus.cpp
+    src/nes/cpu/bus/bus.cpp
+)
+
+nes_add_library(nes-instructions-lib
+    src/nes/cpu/instructions/instructions.cpp
+)
+
+#todo: this lib depends on nes-instructions lib, how can we add lib dependencies too? CMAKE optional parameters? named parameters?
+nes_add_library(nes-instruction-decoder-lib
+    src/nes/cpu/instructions/instruction_decoder.cpp
 )
 
 # TODO: adding tests to the build in required

--- a/lib/nes/CMakeLists.txt
+++ b/lib/nes/CMakeLists.txt
@@ -28,5 +28,6 @@ nes_add_library(nes-instruction-decoder-lib
     src/nes/cpu/instructions/instruction_decoder.cpp
 )
 
+
 # TODO: adding tests to the build in required
 add_subdirectory(tests)

--- a/lib/nes/CMakeLists.txt
+++ b/lib/nes/CMakeLists.txt
@@ -19,6 +19,7 @@ nes_add_library(nes-bus-lib
 
 nes_add_library(nes-instructions-lib
     src/nes/cpu/instructions/instructions.cpp
+    src/nes/cpu/instructions/base_instruction.cpp
 )
 
 #todo: this lib depends on nes-instructions lib, how can we add lib dependencies too? CMAKE optional parameters? named parameters?

--- a/lib/nes/include/nes/cpu/bus/bus.h
+++ b/lib/nes/include/nes/cpu/bus/bus.h
@@ -1,14 +1,14 @@
 #pragma once
 
 #include <vector>
-#include "nes/bus/ibus.h"
+#include <nes/cpu/bus/ibus.h>
 
 namespace nes::peripherals
 {
     class IPeripheral;
 }
 
-namespace nes::bus
+namespace nes::cpu::bus
 {
 
 class Bus : public IBus

--- a/lib/nes/include/nes/cpu/bus/ibus.h
+++ b/lib/nes/include/nes/cpu/bus/ibus.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <nes/peripherals/ipheripheral.h>
 
-namespace nes::bus
+namespace nes::cpu::bus
 {
 
 class IBus

--- a/lib/nes/include/nes/cpu/clock/iclock_sink.h
+++ b/lib/nes/include/nes/cpu/clock/iclock_sink.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace nes::cpu::clock
+{
+    class IClockSink
+    {
+    public:
+        virtual void tick() = 0;
+    };
+}

--- a/lib/nes/include/nes/cpu/clock/iclock_source.h
+++ b/lib/nes/include/nes/cpu/clock/iclock_source.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <nes/cpu/clock/iclock_sink.h>
+
+namespace nes::cpu::clock
+{
+    class IClockSource
+    {
+    public:
+        virtual void start() = 0;
+        virtual void stop() = 0;
+        virtual void addSink(IClockSink& sink);
+    };
+}

--- a/lib/nes/include/nes/cpu/instructions/base_instruction.h
+++ b/lib/nes/include/nes/cpu/instructions/base_instruction.h
@@ -1,0 +1,31 @@
+#pragma once
+#include <nes/cpu/instructions/iinstruction.h>
+#include <nes/cpu/instructions/iinstruction_error_handler.h>
+
+namespace nes::cpu::instructions
+{
+class BaseInstruction : public IInstruction
+{
+private:
+    std::string _name;
+    IInstructionErrorHandler& _handler;
+
+    virtual uint8_t ZeroPage(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t IndexedZeroPage(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t Absolute(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t IndexedAbsolute(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t Indirect(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t Implied(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t Accumulator(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t Immediate(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t Relative(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t IndexedIndirect(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t IndirectIndexed(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    
+
+public:
+    BaseInstruction(std::string&& name, IInstructionErrorHandler& instructionErrorHandler);
+    virtual uint8_t execute(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, AddressingMode mode) override;
+    virtual const std::string& name() const { return _name; }
+};
+}

--- a/lib/nes/include/nes/cpu/instructions/base_instruction.h
+++ b/lib/nes/include/nes/cpu/instructions/base_instruction.h
@@ -62,8 +62,11 @@ protected:
     void performADC(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t value);
     void performSBC(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t value);
 
-    //cmp, cpx, cpy helpers
+    // cmp, cpx, cpy helpers
     void compare(nes::cpu::Registers& registers, uint8_t& reg, uint8_t memory);
+
+    // branching
+    uint8_t branch(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, bool doBranch);
 
 public:
     BaseInstruction(std::string&& name, IInstructionErrorHandler& instructionErrorHandler);

--- a/lib/nes/include/nes/cpu/instructions/base_instruction.h
+++ b/lib/nes/include/nes/cpu/instructions/base_instruction.h
@@ -21,6 +21,7 @@ private:
     virtual uint8_t Relative(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
     virtual uint8_t IndexedIndirect(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
     virtual uint8_t IndirectIndexed(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t Unknown(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
     
 
 public:

--- a/lib/nes/include/nes/cpu/instructions/base_instruction.h
+++ b/lib/nes/include/nes/cpu/instructions/base_instruction.h
@@ -38,11 +38,25 @@ protected:
     uint16_t read16(nes::cpu::bus::IBus& bus, uint16_t addr);
 
     uint16_t getABSXYAddr(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t reg, bool& pageCrossed);
-    uint16_t getZeroPageXAddr(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
-    uint8_t indirectX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
-    uint8_t indirectY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, bool& pageCrossed);
+    uint16_t getZeroPageXYAddr(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t xy);
+
+    uint16_t indirectXAddr(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    uint16_t indirectYAddr(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, bool& pageCrossed);
 
     void    setNZ(nes::cpu::Registers& registers, uint8_t input);
+
+    // LD[x,y,a]
+    uint8_t ldTargetImmediate(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t& target);
+    uint8_t ldTargetZeroPage(nes::cpu::Registers& registers,  nes::cpu::bus::IBus& bus, uint8_t& target);
+    uint8_t ldTargetZeroPageXY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t& target, uint8_t xy);
+    uint8_t ldTargetAbsolute(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t& target);
+    uint8_t ldTargetAbsoluteXY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t& target, uint8_t xy);
+
+    // ST[x,y,a]
+    uint8_t storeZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t value);
+    uint8_t storeZPXY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t value, uint8_t xy);
+    uint8_t storeABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t value);
+    uint8_t storeABSXY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t value, uint8_t xy);
 
 public:
     BaseInstruction(std::string&& name, IInstructionErrorHandler& instructionErrorHandler);

--- a/lib/nes/include/nes/cpu/instructions/base_instruction.h
+++ b/lib/nes/include/nes/cpu/instructions/base_instruction.h
@@ -28,10 +28,21 @@ private:
     virtual uint8_t ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
     virtual uint8_t ZPY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
 
+    
+
 protected:
     // stack operations
     void    push(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t value);
     uint8_t pull(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+
+    uint16_t read16(nes::cpu::bus::IBus& bus, uint16_t addr);
+
+    uint16_t getABSXYAddr(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t reg, bool& pageCrossed);
+    uint16_t getZeroPageXAddr(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    uint8_t indirectX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    uint8_t indirectY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, bool& pageCrossed);
+
+    void    setNZ(nes::cpu::Registers& registers, uint8_t input);
 
 public:
     BaseInstruction(std::string&& name, IInstructionErrorHandler& instructionErrorHandler);

--- a/lib/nes/include/nes/cpu/instructions/base_instruction.h
+++ b/lib/nes/include/nes/cpu/instructions/base_instruction.h
@@ -28,7 +28,8 @@ private:
     virtual uint8_t ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
     virtual uint8_t ZPY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
 
-    
+    // stack operations
+    void push(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t value);
 
 public:
     BaseInstruction(std::string&& name, IInstructionErrorHandler& instructionErrorHandler);

--- a/lib/nes/include/nes/cpu/instructions/base_instruction.h
+++ b/lib/nes/include/nes/cpu/instructions/base_instruction.h
@@ -35,5 +35,6 @@ public:
     virtual uint8_t execute(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
     virtual const std::string& name() const         { return _name; }
     virtual void setMode(const AddressingMode mode) { _mode = mode; }
+    virtual AddressingMode getMode() const          { return _mode; }
 };
 }

--- a/lib/nes/include/nes/cpu/instructions/base_instruction.h
+++ b/lib/nes/include/nes/cpu/instructions/base_instruction.h
@@ -8,25 +8,32 @@ class BaseInstruction : public IInstruction
 {
 private:
     std::string _name;
+    AddressingMode _mode;
     IInstructionErrorHandler& _handler;
 
-    virtual uint8_t ZeroPage(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
-    virtual uint8_t IndexedZeroPage(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
-    virtual uint8_t Absolute(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
-    virtual uint8_t IndexedAbsolute(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
-    virtual uint8_t Indirect(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
-    virtual uint8_t Implied(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
-    virtual uint8_t Accumulator(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
-    virtual uint8_t Immediate(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
-    virtual uint8_t Relative(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
-    virtual uint8_t IndexedIndirect(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
-    virtual uint8_t IndirectIndexed(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
-    virtual uint8_t Unknown(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t ACC(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t IABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t IABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t IIND(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t UNK(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+    virtual uint8_t ZPY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
+
     
 
 public:
     BaseInstruction(std::string&& name, IInstructionErrorHandler& instructionErrorHandler);
-    virtual uint8_t execute(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, AddressingMode mode) override;
-    virtual const std::string& name() const { return _name; }
+    virtual uint8_t execute(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual const std::string& name() const         { return _name; }
+    virtual void setMode(const AddressingMode mode) { _mode = mode; }
 };
 }

--- a/lib/nes/include/nes/cpu/instructions/base_instruction.h
+++ b/lib/nes/include/nes/cpu/instructions/base_instruction.h
@@ -28,8 +28,10 @@ private:
     virtual uint8_t ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
     virtual uint8_t ZPY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
 
+protected:
     // stack operations
-    void push(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t value);
+    void    push(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t value);
+    uint8_t pull(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus);
 
 public:
     BaseInstruction(std::string&& name, IInstructionErrorHandler& instructionErrorHandler);

--- a/lib/nes/include/nes/cpu/instructions/base_instruction.h
+++ b/lib/nes/include/nes/cpu/instructions/base_instruction.h
@@ -58,6 +58,13 @@ protected:
     uint8_t storeABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t value);
     uint8_t storeABSXY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t value, uint8_t xy);
 
+    //adc helper
+    void performADC(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t value);
+    void performSBC(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t value);
+
+    //cmp, cpx, cpy helpers
+    void compare(nes::cpu::Registers& registers, uint8_t& reg, uint8_t memory);
+
 public:
     BaseInstruction(std::string&& name, IInstructionErrorHandler& instructionErrorHandler);
     virtual uint8_t execute(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;

--- a/lib/nes/include/nes/cpu/instructions/iinstruction.h
+++ b/lib/nes/include/nes/cpu/instructions/iinstruction.h
@@ -8,32 +8,45 @@ namespace nes::cpu::instructions
 
 enum class AddressingMode
 {
-    // some positions in the instruction matrix have no definition.
-    // http://archive.6502.org/datasheets/mos_6500_mpu_nov_1985.pdf
-    // note: the thick line ones are new CMOS OpCodes, the NES doesn't use these.
-    Unknown,
-    // Used for pointing to addresses between 0x0000 and 0x00FF.
-    // Because the address is so low, only one byte as opperand is needed
-    // Thus saving ticks.
-    ZeroPage,
-    // Same as ZeroPage, makes use of the Index x/y registers to add a value 
-    IndexedZeroPage,
-    Absolute,
-    IndexedAbsolute,
-    Indirect,
-    Implied,
-    Accumulator,
-    Immediate,
-    Relative,
-    IndexedIndirect,
-    IndirectIndexed,
+    // Unknown: not defined. No addresing mode.
+    UNK,
+    // Absolute addressing
+    ABS,
+    // Absolute indexed X addressing
+    ABSX,
+    // Absolute indexed Y addressing
+    ABSY,
+    // Accumulator addressing
+    ACC,
+    // Indirect absolute addressing
+    IABS,
+    // Indirect absolute indexed X addressing
+    IABSX,
+    // Indirect Indexed addressing
+    IIND,
+    // Indirect Indexed X addressing
+    IINDX,
+    // Indirect Indexed Y addressing
+    IINDY,
+    // Immediate addressing
+    IMM,
+    // Implied addressing
+    IMP,
+    // Relative addressing
+    REL,
+    // Zero page addressing
+    ZP,
+    // Zero page indexed X addressing
+    ZPX,
+    // Zero page indexed Y addressing
+    ZPY,
 };
 
 class IInstruction
 {
     // executes the current instruction.
     // returns the number of ticks this instruction costs
-    virtual uint8_t execute(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, AddressingMode mode) = 0;
+    virtual uint8_t execute(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) = 0;
     virtual const std::string& name() const = 0;
 };
 

--- a/lib/nes/include/nes/cpu/instructions/iinstruction.h
+++ b/lib/nes/include/nes/cpu/instructions/iinstruction.h
@@ -44,6 +44,7 @@ enum class AddressingMode
 
 class IInstruction
 {
+public:
     // executes the current instruction.
     // returns the number of ticks this instruction costs
     virtual uint8_t execute(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) = 0;

--- a/lib/nes/include/nes/cpu/instructions/iinstruction.h
+++ b/lib/nes/include/nes/cpu/instructions/iinstruction.h
@@ -8,6 +8,10 @@ namespace nes::cpu::instructions
 
 enum class AddressingMode
 {
+    // some positions in the instruction matrix have no definition.
+    // http://archive.6502.org/datasheets/mos_6500_mpu_nov_1985.pdf
+    // note: the thick line ones are new CMOS OpCodes, the NES doesn't use these.
+    Unknown,
     // Used for pointing to addresses between 0x0000 and 0x00FF.
     // Because the address is so low, only one byte as opperand is needed
     // Thus saving ticks.

--- a/lib/nes/include/nes/cpu/instructions/iinstruction.h
+++ b/lib/nes/include/nes/cpu/instructions/iinstruction.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <nes/cpu/registers.h>
+#include <nes/cpu/bus/bus.h>
+#include <string>
+
+namespace nes::instructions
+{
+
+enum class AddressingMode
+{
+    ZeroPage,
+    IndexedZeroPage,
+    Absolute,
+    IndexedAbsolute,
+    Indirect,
+    Implied,
+    Accumulator,
+    Immediate,
+    Relative,
+    IndexedIndirect,
+    IndirectIndexed,
+};
+
+class IInstruction
+{
+    IInstruction(std::string& name);
+    virtual void Execute(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, AddressingMode mode) = 0;
+};
+
+}

--- a/lib/nes/include/nes/cpu/instructions/iinstruction.h
+++ b/lib/nes/include/nes/cpu/instructions/iinstruction.h
@@ -3,12 +3,16 @@
 #include <nes/cpu/bus/bus.h>
 #include <string>
 
-namespace nes::instructions
+namespace nes::cpu::instructions
 {
 
 enum class AddressingMode
 {
+    // Used for pointing to addresses between 0x0000 and 0x00FF.
+    // Because the address is so low, only one byte as opperand is needed
+    // Thus saving ticks.
     ZeroPage,
+    // Same as ZeroPage, makes use of the Index x/y registers to add a value 
     IndexedZeroPage,
     Absolute,
     IndexedAbsolute,
@@ -23,8 +27,10 @@ enum class AddressingMode
 
 class IInstruction
 {
-    IInstruction(std::string& name);
-    virtual void Execute(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, AddressingMode mode) = 0;
+    // executes the current instruction.
+    // returns the number of ticks this instruction costs
+    virtual uint8_t execute(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, AddressingMode mode) = 0;
+    virtual const std::string& name() const = 0;
 };
 
 }

--- a/lib/nes/include/nes/cpu/instructions/iinstruction_decoder.h
+++ b/lib/nes/include/nes/cpu/instructions/iinstruction_decoder.h
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace nes::instructions
+namespace nes::cpu::instructions
 {
 
 class IInstructionDecoder

--- a/lib/nes/include/nes/cpu/instructions/iinstruction_decoder.h
+++ b/lib/nes/include/nes/cpu/instructions/iinstruction_decoder.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace nes::instructions
+{
+
+class IInstructionDecoder
+{
+public: 
+    // TODO: make public interface for the instruction decoder.
+
+};
+
+}

--- a/lib/nes/include/nes/cpu/instructions/iinstruction_error_handler.h
+++ b/lib/nes/include/nes/cpu/instructions/iinstruction_error_handler.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <nes/cpu/instructions/iinstruction.h>
+
+namespace nes::cpu::instructions
+{
+
+class IInstructionErrorHandler
+{
+public:
+    virtual void invalidMode(IInstruction& instruction, AddressingMode mode) = 0;
+};
+
+}

--- a/lib/nes/include/nes/cpu/instructions/iinstructionset.h
+++ b/lib/nes/include/nes/cpu/instructions/iinstructionset.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <nes/cpu/instructions/iinstruction.h>
+
+namespace nes::cpu::instructions
+{
+    class IInstructionSet
+    {
+        virtual IInstruction& get(const uint8_t index) = 0;
+    };
+}

--- a/lib/nes/include/nes/cpu/instructions/instruction_decoder.h
+++ b/lib/nes/include/nes/cpu/instructions/instruction_decoder.h
@@ -3,6 +3,8 @@
 #include <nes/cpu/instructions/iinstruction_error_handler.h>
 #include <nes/cpu/instructions/iinstruction.h>
 #include <nes/cpu/instructions/instructionset.h>
+#include <nes/cpu/bus/ibus.h>
+
 namespace nes::cpu::instructions
 {
 
@@ -19,6 +21,11 @@ public:
 class InstructionDecoder : public IInstructionDecoder
 {
 private:
-    AddressingMode _modeMatrix[256];
+    IInstructionSet& _instructionSet;
+    bus::IBus& _bus;
+    Registers& _registers;    
+public:
+    // TODO: interact with the (to be defined) oscillator
+    // Add this to the IInstructionDecoder interface.
 };
 }

--- a/lib/nes/include/nes/cpu/instructions/instruction_decoder.h
+++ b/lib/nes/include/nes/cpu/instructions/instruction_decoder.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <nes/cpu/instructions/iinstruction_decoder.h>
+#include <nes/cpu/instructions/iinstruction_error_handler.h>
+#include <nes/cpu/instructions/iinstruction.h>
+#include <nes/cpu/instructions/instructionset.h>
+namespace nes::cpu::instructions
+{
+
+class TempHandler : public IInstructionErrorHandler
+{
+public:
+    virtual void invalidMode(IInstruction& instruction, AddressingMode mode) override { }
+};
+
+
+
+
+    
+class InstructionDecoder : public IInstructionDecoder
+{
+private:
+    AddressingMode _modeMatrix[256];
+};
+}

--- a/lib/nes/include/nes/cpu/instructions/instructions.h
+++ b/lib/nes/include/nes/cpu/instructions/instructions.h
@@ -1,8 +1,409 @@
 #pragma once
-
+#include <nes/cpu/registers.h>
+#include <nes/cpu/instructions/base_instruction.h>
+#include <nes/cpu/bus/ibus.h>
 namespace nes::cpu::instructions
-[
+{
+//
+// Constructors
+//
 
-// TODO: add individual instructions.
+// Add memory to accumulator with carry
+class ADSInstruction : BaseInstruction
+{
+public:
+    ADSInstruction(IInstructionErrorHandler& handler);
+};
 
-]
+// "AND" memory with accumulator
+class ANDInstruction : BaseInstruction
+{
+public:
+    ANDInstruction(IInstructionErrorHandler& handler);
+};
+
+// Shift left one bit (memory or accumulator)
+class ASLInstruction : BaseInstruction
+{
+public:
+    ASLInstruction(IInstructionErrorHandler& handler);
+};
+
+// Branch on carry clear
+class BCCInstruction : BaseInstruction
+{
+public:
+    BCCInstruction(IInstructionErrorHandler& handler);
+};
+
+// Branch on carry set
+class BCSInstruction : BaseInstruction
+{
+public:
+    BCSInstruction(IInstructionErrorHandler& handler);
+};
+
+// Branch on result zero
+class BEQInstruction : BaseInstruction
+{
+public:
+    BEQInstruction(IInstructionErrorHandler& handler);
+};
+
+// Test bits in memory with accumulator
+class BITInstruction : BaseInstruction
+{
+public:
+    BITInstruction(IInstructionErrorHandler& handler);
+};
+
+// Branch on result minus
+class BMIInstruction : BaseInstruction
+{
+public:
+    BMIInstruction(IInstructionErrorHandler& handler);
+};
+
+// Branch on result not zero
+class BNEInstruction : BaseInstruction
+{
+public:
+    BNEInstruction(IInstructionErrorHandler& handler);
+};
+
+// Branch on result plus
+class BPLInstruction : BaseInstruction
+{
+public:
+    BPLInstruction(IInstructionErrorHandler& handler);
+};
+
+// Force break
+class BRKInstruction : BaseInstruction
+{
+public:
+    BRKInstruction(IInstructionErrorHandler& handler);
+};
+
+// Branch on overflow clear
+class BVCInstruction : BaseInstruction
+{
+public:
+    BVCInstruction(IInstructionErrorHandler& handler);
+};
+
+// Branch on overflow set
+class BVSInstruction : BaseInstruction
+{
+public:
+    BVSInstruction(IInstructionErrorHandler& handler);
+};
+
+// Clear carry flag
+class CLCInstruction : BaseInstruction
+{
+public:
+    CLCInstruction(IInstructionErrorHandler& handler);
+};
+
+// Clear decimal mode
+class CLDInstruction : BaseInstruction
+{
+public:
+    CLDInstruction(IInstructionErrorHandler& handler);
+};
+
+// Clear interrupt disable bit
+class CLIInstruction : BaseInstruction
+{
+public:
+    CLIInstruction(IInstructionErrorHandler& handler);
+};
+
+// Clear overflow flag
+class CLVInstruction : BaseInstruction
+{
+public:
+    CLVInstruction(IInstructionErrorHandler& handler);
+};
+
+// Compare memory and accumulator
+class CMPInstruction : BaseInstruction
+{
+public:
+    CMPInstruction(IInstructionErrorHandler& handler);
+};
+
+// Compare memory and index X
+class CPXInstruction : BaseInstruction
+{
+public:
+    CPXInstruction(IInstructionErrorHandler& handler);
+};
+
+// Compare memory and index Y
+class CPYInstruction : BaseInstruction
+{
+public:
+    CPYInstruction(IInstructionErrorHandler& handler);
+};
+
+// Decrement memory by one
+class DECInstruction : BaseInstruction
+{
+public:
+    DECInstruction(IInstructionErrorHandler& handler);
+};
+
+// Decrement index X by one
+class DEXInstruction : BaseInstruction
+{
+public:
+    DEXInstruction(IInstructionErrorHandler& handler);
+};
+
+// Decrement index Y by one
+class DEYInstruction : BaseInstruction
+{
+public:
+    DEYInstruction(IInstructionErrorHandler& handler);
+};
+
+// "Exclusive or" memory with accumulator
+class EORInstruction : BaseInstruction
+{
+public:
+    EORInstruction(IInstructionErrorHandler& handler);
+};
+
+// Increment memory by one
+class INCInstruction : BaseInstruction
+{
+public:
+    INCInstruction(IInstructionErrorHandler& handler);
+};
+
+// Increment index X by one
+class INXInstruction : BaseInstruction
+{
+public:
+    INXInstruction(IInstructionErrorHandler& handler);
+};
+
+// Increment index Y by one
+class INYInstruction : BaseInstruction
+{
+public:
+    INYInstruction(IInstructionErrorHandler& handler);
+};
+
+// Jump to new location
+class JMPInstruction : BaseInstruction
+{
+public:
+    JMPInstruction(IInstructionErrorHandler& handler);
+};
+
+// Jump to new location saving return address
+class JSRInstruction : BaseInstruction
+{
+public:
+    JSRInstruction(IInstructionErrorHandler& handler);
+};
+
+// Load accumulator with memory
+class LDAInstruction : BaseInstruction
+{
+public:
+    LDAInstruction(IInstructionErrorHandler& handler);
+};
+
+// Load index X with memory
+class LDXInstruction : BaseInstruction
+{
+public:
+    LDXInstruction(IInstructionErrorHandler& handler);
+};
+
+// Load index y with memory
+class LDYInstruction : BaseInstruction
+{
+public:
+    LDYInstruction(IInstructionErrorHandler& handler);
+};
+
+// Shift one bit right (memory or accumulator)
+class LSRInstruction : BaseInstruction
+{
+public:
+    LSRInstruction(IInstructionErrorHandler& handler);
+};
+
+// No operation
+class NOPInstruction : BaseInstruction
+{
+public:
+    NOPInstruction(IInstructionErrorHandler& handler);
+};
+
+// "OR" memory with accumulator
+class ORAInstruction : BaseInstruction
+{
+public:
+    ORAInstruction(IInstructionErrorHandler& handler);
+};
+
+// Push accumulator on stack
+class PHAInstruction : BaseInstruction
+{
+public:
+    PHAInstruction(IInstructionErrorHandler& handler);
+};
+
+// Push processor status on stack
+class PHPInstruction : BaseInstruction
+{
+public:
+    PHPInstruction(IInstructionErrorHandler& handler);
+};
+
+// Pull accumulator from stack
+class PLAInstruction : BaseInstruction
+{
+public:
+    PLAInstruction(IInstructionErrorHandler& handler);
+};
+
+// Pull processor status from stack
+class PLPInstruction : BaseInstruction
+{
+public:
+    PLPInstruction(IInstructionErrorHandler& handler);
+};
+
+// Rotate one bit left (memory or accumulator)
+class ROLInstruction : BaseInstruction
+{
+public:
+    ROLInstruction(IInstructionErrorHandler& handler);
+};
+
+// Rotate one bit right (memory or accumulator)
+class RORInstruction : BaseInstruction
+{
+public:
+    RORInstruction(IInstructionErrorHandler& handler);
+};
+
+// Return from interrupt
+class RTIInstruction : BaseInstruction
+{
+public:
+    RTIInstruction(IInstructionErrorHandler& handler);
+};
+
+// Return from subroutine
+class RTSInstruction : BaseInstruction
+{
+public:
+    RTSInstruction(IInstructionErrorHandler& handler);
+};
+
+// Subtract memory from accumulator with borrow
+class SBCInstruction : BaseInstruction
+{
+public:
+    SBCInstruction(IInstructionErrorHandler& handler);
+};
+
+// Set carry flag
+class SECInstruction : BaseInstruction
+{
+public:
+    SECInstruction(IInstructionErrorHandler& handler);
+};
+
+// Set decimal mode
+class SEDInstruction : BaseInstruction
+{
+public:
+    SEDInstruction(IInstructionErrorHandler& handler);
+};
+
+// Set interrupt disable status
+class SEIInstruction : BaseInstruction
+{
+public:
+    SEIInstruction(IInstructionErrorHandler& handler);
+};
+
+// Store accumulator in memory
+class STAInstruction : BaseInstruction
+{
+public:
+    STAInstruction(IInstructionErrorHandler& handler);
+};
+
+// Store index X in memory
+class STXInstruction : BaseInstruction
+{
+public:
+    STXInstruction(IInstructionErrorHandler& handler);
+};
+
+// Store index Y in memory
+class STYInstruction : BaseInstruction
+{
+public:
+    STYInstruction(IInstructionErrorHandler& handler);
+};
+
+// Transfer accumulator to index X
+class TAXInstruction : BaseInstruction
+{
+public:
+    TAXInstruction(IInstructionErrorHandler& handler);
+};
+
+// Transfer accumulator to index Y
+class TAYInstruction : BaseInstruction
+{
+public:
+    TAYInstruction(IInstructionErrorHandler& handler);
+};
+
+// Transfer stack pointer to index X
+class TSXInstruction : BaseInstruction
+{
+public:
+    TSXInstruction(IInstructionErrorHandler& handler);
+};
+
+// Transfer index X to accumulator
+class TXAInstruction : BaseInstruction
+{
+public:
+    TXAInstruction(IInstructionErrorHandler& handler);
+};
+
+// Transfer index X to stack register
+class TXSInstruction : BaseInstruction
+{
+public:
+    TXSInstruction(IInstructionErrorHandler& handler);
+};
+
+// Transfer index Y to accumulator
+class TYAInstruction : BaseInstruction
+{
+public:
+    TYAInstruction(IInstructionErrorHandler& handler);
+};
+
+//
+// OpCode implementations
+//
+
+
+
+}

--- a/lib/nes/include/nes/cpu/instructions/instructions.h
+++ b/lib/nes/include/nes/cpu/instructions/instructions.h
@@ -4,335 +4,308 @@
 #include <nes/cpu/bus/ibus.h>
 namespace nes::cpu::instructions
 {
-//
-// Constructors
-//
-
-// Add memory to accumulator with carry
-class ADCInstruction : public BaseInstruction
+// Force break
+class BRKInstruction : public BaseInstruction
 {
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
 public:
-    ADCInstruction(IInstructionErrorHandler& handler);
+    BRKInstruction(IInstructionErrorHandler& handler);
 };
 
-// "AND" memory with accumulator
-class ANDInstruction : public BaseInstruction
+// 'OR' memory with accumulator
+class ORAInstruction : public BaseInstruction
 {
+private:
+    virtual uint8_t IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
 public:
-    ANDInstruction(IInstructionErrorHandler& handler);
+    ORAInstruction(IInstructionErrorHandler& handler);
 };
 
 // Shift left one bit (memory or accumulator)
 class ASLInstruction : public BaseInstruction
 {
+private:
+    virtual uint8_t ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ACC(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
 public:
     ASLInstruction(IInstructionErrorHandler& handler);
-};
-
-// Branch on carry clear
-class BCCInstruction : public BaseInstruction
-{
-public:
-    BCCInstruction(IInstructionErrorHandler& handler);
-};
-
-// Branch on carry set
-class BCSInstruction : public BaseInstruction
-{
-public:
-    BCSInstruction(IInstructionErrorHandler& handler);
-};
-
-// Branch on result zero
-class BEQInstruction : public BaseInstruction
-{
-public:
-    BEQInstruction(IInstructionErrorHandler& handler);
-};
-
-// Test bits in memory with accumulator
-class BITInstruction : public BaseInstruction
-{
-public:
-    BITInstruction(IInstructionErrorHandler& handler);
-};
-
-// Branch on result minus
-class BMIInstruction : public BaseInstruction
-{
-public:
-    BMIInstruction(IInstructionErrorHandler& handler);
-};
-
-// Branch on result not zero
-class BNEInstruction : public BaseInstruction
-{
-public:
-    BNEInstruction(IInstructionErrorHandler& handler);
-};
-
-// Branch on result plus
-class BPLInstruction : public BaseInstruction
-{
-public:
-    BPLInstruction(IInstructionErrorHandler& handler);
-};
-
-// Force break
-class BRKInstruction : public BaseInstruction
-{
-public:
-    BRKInstruction(IInstructionErrorHandler& handler);
-};
-
-// Branch on overflow clear
-class BVCInstruction : public BaseInstruction
-{
-public:
-    BVCInstruction(IInstructionErrorHandler& handler);
-};
-
-// Branch on overflow set
-class BVSInstruction : public BaseInstruction
-{
-public:
-    BVSInstruction(IInstructionErrorHandler& handler);
-};
-
-// Clear carry flag
-class CLCInstruction : public BaseInstruction
-{
-public:
-    CLCInstruction(IInstructionErrorHandler& handler);
-};
-
-// Clear decimal mode
-class CLDInstruction : public BaseInstruction
-{
-public:
-    CLDInstruction(IInstructionErrorHandler& handler);
-};
-
-// Clear interrupt disable bit
-class CLIInstruction : public BaseInstruction
-{
-public:
-    CLIInstruction(IInstructionErrorHandler& handler);
-};
-
-// Clear overflow flag
-class CLVInstruction : public BaseInstruction
-{
-public:
-    CLVInstruction(IInstructionErrorHandler& handler);
-};
-
-// Compare memory and accumulator
-class CMPInstruction : public BaseInstruction
-{
-public:
-    CMPInstruction(IInstructionErrorHandler& handler);
-};
-
-// Compare memory and index X
-class CPXInstruction : public BaseInstruction
-{
-public:
-    CPXInstruction(IInstructionErrorHandler& handler);
-};
-
-// Compare memory and index Y
-class CPYInstruction : public BaseInstruction
-{
-public:
-    CPYInstruction(IInstructionErrorHandler& handler);
-};
-
-// Decrement memory by one
-class DECInstruction : public BaseInstruction
-{
-public:
-    DECInstruction(IInstructionErrorHandler& handler);
-};
-
-// Decrement index X by one
-class DEXInstruction : public BaseInstruction
-{
-public:
-    DEXInstruction(IInstructionErrorHandler& handler);
-};
-
-// Decrement index Y by one
-class DEYInstruction : public BaseInstruction
-{
-public:
-    DEYInstruction(IInstructionErrorHandler& handler);
-};
-
-// "Exclusive or" memory with accumulator
-class EORInstruction : public BaseInstruction
-{
-public:
-    EORInstruction(IInstructionErrorHandler& handler);
-};
-
-// Increment memory by one
-class INCInstruction : public BaseInstruction
-{
-public:
-    INCInstruction(IInstructionErrorHandler& handler);
-};
-
-// Increment index X by one
-class INXInstruction : public BaseInstruction
-{
-public:
-    INXInstruction(IInstructionErrorHandler& handler);
-};
-
-// Increment index Y by one
-class INYInstruction : public BaseInstruction
-{
-public:
-    INYInstruction(IInstructionErrorHandler& handler);
-};
-
-// Jump to new location
-class JMPInstruction : public BaseInstruction
-{
-public:
-    JMPInstruction(IInstructionErrorHandler& handler);
-};
-
-// Jump to new location saving return address
-class JSRInstruction : public BaseInstruction
-{
-public:
-    JSRInstruction(IInstructionErrorHandler& handler);
-};
-
-// Load accumulator with memory
-class LDAInstruction : public BaseInstruction
-{
-public:
-    LDAInstruction(IInstructionErrorHandler& handler);
-};
-
-// Load index X with memory
-class LDXInstruction : public BaseInstruction
-{
-public:
-    LDXInstruction(IInstructionErrorHandler& handler);
-};
-
-// Load index y with memory
-class LDYInstruction : public BaseInstruction
-{
-public:
-    LDYInstruction(IInstructionErrorHandler& handler);
-};
-
-// Shift one bit right (memory or accumulator)
-class LSRInstruction : public BaseInstruction
-{
-public:
-    LSRInstruction(IInstructionErrorHandler& handler);
-};
-
-// No operation
-class NOPInstruction : public BaseInstruction
-{
-public:
-    NOPInstruction(IInstructionErrorHandler& handler);
-};
-
-// "OR" memory with accumulator
-class ORAInstruction : public BaseInstruction
-{
-public:
-    ORAInstruction(IInstructionErrorHandler& handler);
-};
-
-// Push accumulator on stack
-class PHAInstruction : public BaseInstruction
-{
-public:
-    PHAInstruction(IInstructionErrorHandler& handler);
 };
 
 // Push processor status on stack
 class PHPInstruction : public BaseInstruction
 {
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
 public:
     PHPInstruction(IInstructionErrorHandler& handler);
 };
 
-// Pull accumulator from stack
-class PLAInstruction : public BaseInstruction
+// Branch on result plus
+class BPLInstruction : public BaseInstruction
 {
+private:
+    virtual uint8_t REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
 public:
-    PLAInstruction(IInstructionErrorHandler& handler);
+    BPLInstruction(IInstructionErrorHandler& handler);
 };
 
-// Pull processor status from stack
-class PLPInstruction : public BaseInstruction
+// Clear carry flag
+class CLCInstruction : public BaseInstruction
 {
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
 public:
-    PLPInstruction(IInstructionErrorHandler& handler);
+    CLCInstruction(IInstructionErrorHandler& handler);
+};
+
+// Jump to new location saving return address
+class JSRInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    JSRInstruction(IInstructionErrorHandler& handler);
+};
+
+// 'AND' memory with accumulator
+class ANDInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    ANDInstruction(IInstructionErrorHandler& handler);
+};
+
+// Test bits in memory with accumulator
+class BITInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    BITInstruction(IInstructionErrorHandler& handler);
 };
 
 // Rotate one bit left (memory or accumulator)
 class ROLInstruction : public BaseInstruction
 {
+private:
+    virtual uint8_t ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ACC(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
 public:
     ROLInstruction(IInstructionErrorHandler& handler);
 };
 
-// Rotate one bit right (memory or accumulator)
-class RORInstruction : public BaseInstruction
+// Pull processor status from stack
+class PLPInstruction : public BaseInstruction
 {
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
 public:
-    RORInstruction(IInstructionErrorHandler& handler);
+    PLPInstruction(IInstructionErrorHandler& handler);
 };
 
-// Return from interrupt
-class RTIInstruction : public BaseInstruction
+// Branch on result minus
+class BMIInstruction : public BaseInstruction
 {
-public:
-    RTIInstruction(IInstructionErrorHandler& handler);
-};
+private:
+    virtual uint8_t REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
 
-// Return from subroutine
-class RTSInstruction : public BaseInstruction
-{
 public:
-    RTSInstruction(IInstructionErrorHandler& handler);
-};
-
-// Subtract memory from accumulator with borrow
-class SBCInstruction : public BaseInstruction
-{
-public:
-    SBCInstruction(IInstructionErrorHandler& handler);
+    BMIInstruction(IInstructionErrorHandler& handler);
 };
 
 // Set carry flag
 class SECInstruction : public BaseInstruction
 {
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
 public:
     SECInstruction(IInstructionErrorHandler& handler);
 };
 
-// Set decimal mode
-class SEDInstruction : public BaseInstruction
+// Return from interrupt
+class RTIInstruction : public BaseInstruction
 {
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
 public:
-    SEDInstruction(IInstructionErrorHandler& handler);
+    RTIInstruction(IInstructionErrorHandler& handler);
+};
+
+// 'Exclusive or' memory with accumulator
+class EORInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    EORInstruction(IInstructionErrorHandler& handler);
+};
+
+// Shift one bit right (memory or accumulator)
+class LSRInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ACC(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    LSRInstruction(IInstructionErrorHandler& handler);
+};
+
+// Push accumulator on stack
+class PHAInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    PHAInstruction(IInstructionErrorHandler& handler);
+};
+
+// Jump to new location
+class JMPInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t IABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    JMPInstruction(IInstructionErrorHandler& handler);
+};
+
+// Branch on overflow clear
+class BVCInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    BVCInstruction(IInstructionErrorHandler& handler);
+};
+
+// Clear interrupt disable bit
+class CLIInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    CLIInstruction(IInstructionErrorHandler& handler);
+};
+
+// Return from subroutine
+class RTSInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    RTSInstruction(IInstructionErrorHandler& handler);
+};
+
+// Add memory to accumulator with carry
+class ADCInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    ADCInstruction(IInstructionErrorHandler& handler);
+};
+
+// Rotate one bit right (memory or accumulator)
+class RORInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ACC(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    RORInstruction(IInstructionErrorHandler& handler);
+};
+
+// Pull accumulator from stack
+class PLAInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    PLAInstruction(IInstructionErrorHandler& handler);
+};
+
+// Branch on overflow set
+class BVSInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    BVSInstruction(IInstructionErrorHandler& handler);
 };
 
 // Set interrupt disable status
 class SEIInstruction : public BaseInstruction
 {
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
 public:
     SEIInstruction(IInstructionErrorHandler& handler);
 };
@@ -340,63 +313,350 @@ public:
 // Store accumulator in memory
 class STAInstruction : public BaseInstruction
 {
+private:
+    virtual uint8_t IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
 public:
     STAInstruction(IInstructionErrorHandler& handler);
-};
-
-// Store index X in memory
-class STXInstruction : public BaseInstruction
-{
-public:
-    STXInstruction(IInstructionErrorHandler& handler);
 };
 
 // Store index Y in memory
 class STYInstruction : public BaseInstruction
 {
+private:
+    virtual uint8_t ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
 public:
     STYInstruction(IInstructionErrorHandler& handler);
 };
 
-// Transfer accumulator to index X
-class TAXInstruction : public BaseInstruction
+// Store index X in memory
+class STXInstruction : public BaseInstruction
 {
+private:
+    virtual uint8_t ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZPY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
 public:
-    TAXInstruction(IInstructionErrorHandler& handler);
+    STXInstruction(IInstructionErrorHandler& handler);
 };
 
-// Transfer accumulator to index Y
-class TAYInstruction : public BaseInstruction
+// Decrement index Y by one
+class DEYInstruction : public BaseInstruction
 {
-public:
-    TAYInstruction(IInstructionErrorHandler& handler);
-};
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
 
-// Transfer stack pointer to index X
-class TSXInstruction : public BaseInstruction
-{
 public:
-    TSXInstruction(IInstructionErrorHandler& handler);
+    DEYInstruction(IInstructionErrorHandler& handler);
 };
 
 // Transfer index X to accumulator
 class TXAInstruction : public BaseInstruction
 {
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
 public:
     TXAInstruction(IInstructionErrorHandler& handler);
 };
 
-// Transfer index X to stack register
-class TXSInstruction : public BaseInstruction
+// Branch on carry clear
+class BCCInstruction : public BaseInstruction
 {
+private:
+    virtual uint8_t REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
 public:
-    TXSInstruction(IInstructionErrorHandler& handler);
+    BCCInstruction(IInstructionErrorHandler& handler);
 };
 
 // Transfer index Y to accumulator
 class TYAInstruction : public BaseInstruction
 {
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
 public:
     TYAInstruction(IInstructionErrorHandler& handler);
 };
+
+// Transfer index X to stack register
+class TXSInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    TXSInstruction(IInstructionErrorHandler& handler);
+};
+
+// Load index y with memory
+class LDYInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    LDYInstruction(IInstructionErrorHandler& handler);
+};
+
+// Load accumulator with memory
+class LDAInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    LDAInstruction(IInstructionErrorHandler& handler);
+};
+
+// Load index X with memory
+class LDXInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZPY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    LDXInstruction(IInstructionErrorHandler& handler);
+};
+
+// Transfer accumulator to index Y
+class TAYInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    TAYInstruction(IInstructionErrorHandler& handler);
+};
+
+// Transfer accumulator to index X
+class TAXInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    TAXInstruction(IInstructionErrorHandler& handler);
+};
+
+// Branch on carry set
+class BCSInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    BCSInstruction(IInstructionErrorHandler& handler);
+};
+
+// Clear overflow flag
+class CLVInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    CLVInstruction(IInstructionErrorHandler& handler);
+};
+
+// Transfer stack pointer to index X
+class TSXInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    TSXInstruction(IInstructionErrorHandler& handler);
+};
+
+// Compare memory and index Y
+class CPYInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    CPYInstruction(IInstructionErrorHandler& handler);
+};
+
+// Compare memory and accumulator
+class CMPInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    CMPInstruction(IInstructionErrorHandler& handler);
+};
+
+// Decrement memory by one
+class DECInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    DECInstruction(IInstructionErrorHandler& handler);
+};
+
+// Increment index Y by one
+class INYInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    INYInstruction(IInstructionErrorHandler& handler);
+};
+
+// Decrement index X by one
+class DEXInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    DEXInstruction(IInstructionErrorHandler& handler);
+};
+
+// Branch on result not zero
+class BNEInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    BNEInstruction(IInstructionErrorHandler& handler);
+};
+
+// Clear decimal mode
+class CLDInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    CLDInstruction(IInstructionErrorHandler& handler);
+};
+
+// Compare memory and index X
+class CPXInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    CPXInstruction(IInstructionErrorHandler& handler);
+};
+
+// Subtract memory from accumulator with borrow
+class SBCInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    SBCInstruction(IInstructionErrorHandler& handler);
+};
+
+// Increment memory by one
+class INCInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+    virtual uint8_t ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    INCInstruction(IInstructionErrorHandler& handler);
+};
+
+// Increment index X by one
+class INXInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    INXInstruction(IInstructionErrorHandler& handler);
+};
+
+// No operation
+class NOPInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    NOPInstruction(IInstructionErrorHandler& handler);
+};
+
+// Branch on result zero
+class BEQInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    BEQInstruction(IInstructionErrorHandler& handler);
+};
+
+// Set decimal mode
+class SEDInstruction : public BaseInstruction
+{
+private:
+    virtual uint8_t IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) override;
+
+public:
+    SEDInstruction(IInstructionErrorHandler& handler);
+};
+
 }

--- a/lib/nes/include/nes/cpu/instructions/instructions.h
+++ b/lib/nes/include/nes/cpu/instructions/instructions.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace nes::cpu::instructions
+[
+
+// TODO: add individual instructions.
+
+]

--- a/lib/nes/include/nes/cpu/instructions/instructions.h
+++ b/lib/nes/include/nes/cpu/instructions/instructions.h
@@ -9,401 +9,394 @@ namespace nes::cpu::instructions
 //
 
 // Add memory to accumulator with carry
-class ADSInstruction : BaseInstruction
+class ADCInstruction : public BaseInstruction
 {
 public:
-    ADSInstruction(IInstructionErrorHandler& handler);
+    ADCInstruction(IInstructionErrorHandler& handler);
 };
 
 // "AND" memory with accumulator
-class ANDInstruction : BaseInstruction
+class ANDInstruction : public BaseInstruction
 {
 public:
     ANDInstruction(IInstructionErrorHandler& handler);
 };
 
 // Shift left one bit (memory or accumulator)
-class ASLInstruction : BaseInstruction
+class ASLInstruction : public BaseInstruction
 {
 public:
     ASLInstruction(IInstructionErrorHandler& handler);
 };
 
 // Branch on carry clear
-class BCCInstruction : BaseInstruction
+class BCCInstruction : public BaseInstruction
 {
 public:
     BCCInstruction(IInstructionErrorHandler& handler);
 };
 
 // Branch on carry set
-class BCSInstruction : BaseInstruction
+class BCSInstruction : public BaseInstruction
 {
 public:
     BCSInstruction(IInstructionErrorHandler& handler);
 };
 
 // Branch on result zero
-class BEQInstruction : BaseInstruction
+class BEQInstruction : public BaseInstruction
 {
 public:
     BEQInstruction(IInstructionErrorHandler& handler);
 };
 
 // Test bits in memory with accumulator
-class BITInstruction : BaseInstruction
+class BITInstruction : public BaseInstruction
 {
 public:
     BITInstruction(IInstructionErrorHandler& handler);
 };
 
 // Branch on result minus
-class BMIInstruction : BaseInstruction
+class BMIInstruction : public BaseInstruction
 {
 public:
     BMIInstruction(IInstructionErrorHandler& handler);
 };
 
 // Branch on result not zero
-class BNEInstruction : BaseInstruction
+class BNEInstruction : public BaseInstruction
 {
 public:
     BNEInstruction(IInstructionErrorHandler& handler);
 };
 
 // Branch on result plus
-class BPLInstruction : BaseInstruction
+class BPLInstruction : public BaseInstruction
 {
 public:
     BPLInstruction(IInstructionErrorHandler& handler);
 };
 
 // Force break
-class BRKInstruction : BaseInstruction
+class BRKInstruction : public BaseInstruction
 {
 public:
     BRKInstruction(IInstructionErrorHandler& handler);
 };
 
 // Branch on overflow clear
-class BVCInstruction : BaseInstruction
+class BVCInstruction : public BaseInstruction
 {
 public:
     BVCInstruction(IInstructionErrorHandler& handler);
 };
 
 // Branch on overflow set
-class BVSInstruction : BaseInstruction
+class BVSInstruction : public BaseInstruction
 {
 public:
     BVSInstruction(IInstructionErrorHandler& handler);
 };
 
 // Clear carry flag
-class CLCInstruction : BaseInstruction
+class CLCInstruction : public BaseInstruction
 {
 public:
     CLCInstruction(IInstructionErrorHandler& handler);
 };
 
 // Clear decimal mode
-class CLDInstruction : BaseInstruction
+class CLDInstruction : public BaseInstruction
 {
 public:
     CLDInstruction(IInstructionErrorHandler& handler);
 };
 
 // Clear interrupt disable bit
-class CLIInstruction : BaseInstruction
+class CLIInstruction : public BaseInstruction
 {
 public:
     CLIInstruction(IInstructionErrorHandler& handler);
 };
 
 // Clear overflow flag
-class CLVInstruction : BaseInstruction
+class CLVInstruction : public BaseInstruction
 {
 public:
     CLVInstruction(IInstructionErrorHandler& handler);
 };
 
 // Compare memory and accumulator
-class CMPInstruction : BaseInstruction
+class CMPInstruction : public BaseInstruction
 {
 public:
     CMPInstruction(IInstructionErrorHandler& handler);
 };
 
 // Compare memory and index X
-class CPXInstruction : BaseInstruction
+class CPXInstruction : public BaseInstruction
 {
 public:
     CPXInstruction(IInstructionErrorHandler& handler);
 };
 
 // Compare memory and index Y
-class CPYInstruction : BaseInstruction
+class CPYInstruction : public BaseInstruction
 {
 public:
     CPYInstruction(IInstructionErrorHandler& handler);
 };
 
 // Decrement memory by one
-class DECInstruction : BaseInstruction
+class DECInstruction : public BaseInstruction
 {
 public:
     DECInstruction(IInstructionErrorHandler& handler);
 };
 
 // Decrement index X by one
-class DEXInstruction : BaseInstruction
+class DEXInstruction : public BaseInstruction
 {
 public:
     DEXInstruction(IInstructionErrorHandler& handler);
 };
 
 // Decrement index Y by one
-class DEYInstruction : BaseInstruction
+class DEYInstruction : public BaseInstruction
 {
 public:
     DEYInstruction(IInstructionErrorHandler& handler);
 };
 
 // "Exclusive or" memory with accumulator
-class EORInstruction : BaseInstruction
+class EORInstruction : public BaseInstruction
 {
 public:
     EORInstruction(IInstructionErrorHandler& handler);
 };
 
 // Increment memory by one
-class INCInstruction : BaseInstruction
+class INCInstruction : public BaseInstruction
 {
 public:
     INCInstruction(IInstructionErrorHandler& handler);
 };
 
 // Increment index X by one
-class INXInstruction : BaseInstruction
+class INXInstruction : public BaseInstruction
 {
 public:
     INXInstruction(IInstructionErrorHandler& handler);
 };
 
 // Increment index Y by one
-class INYInstruction : BaseInstruction
+class INYInstruction : public BaseInstruction
 {
 public:
     INYInstruction(IInstructionErrorHandler& handler);
 };
 
 // Jump to new location
-class JMPInstruction : BaseInstruction
+class JMPInstruction : public BaseInstruction
 {
 public:
     JMPInstruction(IInstructionErrorHandler& handler);
 };
 
 // Jump to new location saving return address
-class JSRInstruction : BaseInstruction
+class JSRInstruction : public BaseInstruction
 {
 public:
     JSRInstruction(IInstructionErrorHandler& handler);
 };
 
 // Load accumulator with memory
-class LDAInstruction : BaseInstruction
+class LDAInstruction : public BaseInstruction
 {
 public:
     LDAInstruction(IInstructionErrorHandler& handler);
 };
 
 // Load index X with memory
-class LDXInstruction : BaseInstruction
+class LDXInstruction : public BaseInstruction
 {
 public:
     LDXInstruction(IInstructionErrorHandler& handler);
 };
 
 // Load index y with memory
-class LDYInstruction : BaseInstruction
+class LDYInstruction : public BaseInstruction
 {
 public:
     LDYInstruction(IInstructionErrorHandler& handler);
 };
 
 // Shift one bit right (memory or accumulator)
-class LSRInstruction : BaseInstruction
+class LSRInstruction : public BaseInstruction
 {
 public:
     LSRInstruction(IInstructionErrorHandler& handler);
 };
 
 // No operation
-class NOPInstruction : BaseInstruction
+class NOPInstruction : public BaseInstruction
 {
 public:
     NOPInstruction(IInstructionErrorHandler& handler);
 };
 
 // "OR" memory with accumulator
-class ORAInstruction : BaseInstruction
+class ORAInstruction : public BaseInstruction
 {
 public:
     ORAInstruction(IInstructionErrorHandler& handler);
 };
 
 // Push accumulator on stack
-class PHAInstruction : BaseInstruction
+class PHAInstruction : public BaseInstruction
 {
 public:
     PHAInstruction(IInstructionErrorHandler& handler);
 };
 
 // Push processor status on stack
-class PHPInstruction : BaseInstruction
+class PHPInstruction : public BaseInstruction
 {
 public:
     PHPInstruction(IInstructionErrorHandler& handler);
 };
 
 // Pull accumulator from stack
-class PLAInstruction : BaseInstruction
+class PLAInstruction : public BaseInstruction
 {
 public:
     PLAInstruction(IInstructionErrorHandler& handler);
 };
 
 // Pull processor status from stack
-class PLPInstruction : BaseInstruction
+class PLPInstruction : public BaseInstruction
 {
 public:
     PLPInstruction(IInstructionErrorHandler& handler);
 };
 
 // Rotate one bit left (memory or accumulator)
-class ROLInstruction : BaseInstruction
+class ROLInstruction : public BaseInstruction
 {
 public:
     ROLInstruction(IInstructionErrorHandler& handler);
 };
 
 // Rotate one bit right (memory or accumulator)
-class RORInstruction : BaseInstruction
+class RORInstruction : public BaseInstruction
 {
 public:
     RORInstruction(IInstructionErrorHandler& handler);
 };
 
 // Return from interrupt
-class RTIInstruction : BaseInstruction
+class RTIInstruction : public BaseInstruction
 {
 public:
     RTIInstruction(IInstructionErrorHandler& handler);
 };
 
 // Return from subroutine
-class RTSInstruction : BaseInstruction
+class RTSInstruction : public BaseInstruction
 {
 public:
     RTSInstruction(IInstructionErrorHandler& handler);
 };
 
 // Subtract memory from accumulator with borrow
-class SBCInstruction : BaseInstruction
+class SBCInstruction : public BaseInstruction
 {
 public:
     SBCInstruction(IInstructionErrorHandler& handler);
 };
 
 // Set carry flag
-class SECInstruction : BaseInstruction
+class SECInstruction : public BaseInstruction
 {
 public:
     SECInstruction(IInstructionErrorHandler& handler);
 };
 
 // Set decimal mode
-class SEDInstruction : BaseInstruction
+class SEDInstruction : public BaseInstruction
 {
 public:
     SEDInstruction(IInstructionErrorHandler& handler);
 };
 
 // Set interrupt disable status
-class SEIInstruction : BaseInstruction
+class SEIInstruction : public BaseInstruction
 {
 public:
     SEIInstruction(IInstructionErrorHandler& handler);
 };
 
 // Store accumulator in memory
-class STAInstruction : BaseInstruction
+class STAInstruction : public BaseInstruction
 {
 public:
     STAInstruction(IInstructionErrorHandler& handler);
 };
 
 // Store index X in memory
-class STXInstruction : BaseInstruction
+class STXInstruction : public BaseInstruction
 {
 public:
     STXInstruction(IInstructionErrorHandler& handler);
 };
 
 // Store index Y in memory
-class STYInstruction : BaseInstruction
+class STYInstruction : public BaseInstruction
 {
 public:
     STYInstruction(IInstructionErrorHandler& handler);
 };
 
 // Transfer accumulator to index X
-class TAXInstruction : BaseInstruction
+class TAXInstruction : public BaseInstruction
 {
 public:
     TAXInstruction(IInstructionErrorHandler& handler);
 };
 
 // Transfer accumulator to index Y
-class TAYInstruction : BaseInstruction
+class TAYInstruction : public BaseInstruction
 {
 public:
     TAYInstruction(IInstructionErrorHandler& handler);
 };
 
 // Transfer stack pointer to index X
-class TSXInstruction : BaseInstruction
+class TSXInstruction : public BaseInstruction
 {
 public:
     TSXInstruction(IInstructionErrorHandler& handler);
 };
 
 // Transfer index X to accumulator
-class TXAInstruction : BaseInstruction
+class TXAInstruction : public BaseInstruction
 {
 public:
     TXAInstruction(IInstructionErrorHandler& handler);
 };
 
 // Transfer index X to stack register
-class TXSInstruction : BaseInstruction
+class TXSInstruction : public BaseInstruction
 {
 public:
     TXSInstruction(IInstructionErrorHandler& handler);
 };
 
 // Transfer index Y to accumulator
-class TYAInstruction : BaseInstruction
+class TYAInstruction : public BaseInstruction
 {
 public:
     TYAInstruction(IInstructionErrorHandler& handler);
 };
-
-//
-// OpCode implementations
-//
-
-
-
 }

--- a/lib/nes/include/nes/cpu/instructions/instructionset.h
+++ b/lib/nes/include/nes/cpu/instructions/instructionset.h
@@ -1,0 +1,72 @@
+#pragma once
+#include <nes/cpu/instructions/instructions.h>
+#include <nes/cpu/instructions/iinstructionset.h>
+
+namespace nes::cpu::instructions
+{
+class InstructionSet : public IInstructionSet
+{
+private:
+    ADCInstruction _adc;
+    ANDInstruction _and;
+    ASLInstruction _asl;
+    BCCInstruction _bcc;
+    BCSInstruction _bcs;
+    BEQInstruction _beq;
+    BITInstruction _bit;
+    BMIInstruction _bmi;
+    BNEInstruction _bne;
+    BPLInstruction _bpl;
+    BRKInstruction _brk;
+    BVCInstruction _bvc;
+    BVSInstruction _bvs;
+    CLCInstruction _clc;
+    CLDInstruction _cld;
+    CLIInstruction _cli;
+    CLVInstruction _clv;
+    CMPInstruction _cmp;
+    CPXInstruction _cpx;
+    CPYInstruction _cpy;
+    DECInstruction _dec;
+    DEXInstruction _dex;
+    DEYInstruction _dey;
+    EORInstruction _eor;
+    INCInstruction _inc;
+    INXInstruction _inx;
+    INYInstruction _iny;
+    JMPInstruction _jmp;
+    JSRInstruction _jsr;
+    LDAInstruction _lda;
+    LDXInstruction _ldx;
+    LDYInstruction _ldy;
+    LSRInstruction _lsr;
+    NOPInstruction _nop;
+    ORAInstruction _ora;
+    PHAInstruction _pha;
+    PHPInstruction _php;
+    PLAInstruction _pla;
+    PLPInstruction _plp;
+    ROLInstruction _rol;
+    RORInstruction _ror;
+    RTIInstruction _rti;
+    RTSInstruction _rts;
+    SBCInstruction _sbc;
+    SECInstruction _sec;
+    SEDInstruction _sed;
+    SEIInstruction _sei;
+    STAInstruction _sta;
+    STXInstruction _stx;
+    STYInstruction _sty;
+    TAXInstruction _tax;
+    TAYInstruction _tay;
+    TSXInstruction _tsx;
+    TXAInstruction _txa;
+    TXSInstruction _txs;
+    TYAInstruction _tya;
+    BaseInstruction _unk;
+    IInstruction* _instructionMatrix[256];
+public:
+    InstructionSet(IInstructionErrorHandler& handler);
+    virtual IInstruction& get(const uint8_t index) override { return *_instructionMatrix[index]; }
+};
+}

--- a/lib/nes/include/nes/cpu/instructions/instructionset.h
+++ b/lib/nes/include/nes/cpu/instructions/instructionset.h
@@ -64,9 +64,10 @@ private:
     TXSInstruction _txs;
     TYAInstruction _tya;
     BaseInstruction _unk;
-    IInstruction* _instructionMatrix[256];
+    BaseInstruction* _instructionMatrix[256];
+    AddressingMode _addressingModeMatrix[256];
 public:
     InstructionSet(IInstructionErrorHandler& handler);
-    virtual IInstruction& get(const uint8_t index) override { return *_instructionMatrix[index]; }
+    virtual IInstruction& get(const uint8_t index) override;
 };
 }

--- a/lib/nes/include/nes/cpu/registers.h
+++ b/lib/nes/include/nes/cpu/registers.h
@@ -23,6 +23,18 @@ public:
     bool z : 1;
     // Carry 1 = true
     bool c : 1;
+
+    uint8_t toByte() const { return n << 7 | u << 6 | v << 5 | b << 4 | d << 3 | i << 2 | z << 1 | c; }
+    void    fromByte(uint8_t data) { 
+        n = data & (1 << 7); 
+        u = data & (1 << 6);
+        v = data & (1 << 5);
+        b = data & (1 << 4);
+        d = data & (1 << 3);
+        i = data & (1 << 2);
+        z = data & (1 << 1);
+        c = data & (1 << 0);
+    }
 };
 
 struct Registers
@@ -42,21 +54,6 @@ struct Registers
 
     void reset() { reset(0xfffc); } // default boot address
     void reset(uint16_t startAddress)  { a = 0; x = 0; y = 0; pc = 0; sp = 0xfd; p.n = 0; p.u = true; p.v = false; p.b = false; p.d = false; p.i = false; p.z = false; p.c = false;}
-    bool operator==(const Registers& r) const
-    {
-        return a   == r.a   &&
-               x   == r.x   &&
-               y   == r.y   &&
-               pc  == r.pc  &&
-               p.n == r.p.n &&
-               p.u == r.p.u &&
-               p.v == r.p.v &&
-               p.b == r.p.b &&
-               p.d == r.p.d &&
-               p.i == r.p.i &&
-               p.z == r.p.z &&
-               p.c == r.p.c;
-    }
 };
 
 }

--- a/lib/nes/include/nes/cpu/registers.h
+++ b/lib/nes/include/nes/cpu/registers.h
@@ -9,8 +9,10 @@ struct ProcessorStatusRegister
 public:
     // Negative (1 = negative)
     bool n : 1;
+    // Unused bit. do not alter.
+    bool u : 1;
     // Overflow 1 = true
-    bool v : 2;
+    bool v : 1;
     // BRK command
     bool b : 1;
     // Decimal Mode 1 = true (not used for the NES)
@@ -37,6 +39,24 @@ struct Registers
     uint16_t sp;
     // Processor status register
     ProcessorStatusRegister p;
+
+    void reset() { reset(0xfffc); } // default boot address
+    void reset(uint16_t startAddress)  { a = 0; x = 0; y = 0; pc = 0; sp = 0xfd; p.n = 0; p.u = true; p.v = false; p.b = false; p.d = false; p.i = false; p.z = false; p.c = false;}
+    bool operator==(const Registers& r) const
+    {
+        return a   == r.a   &&
+               x   == r.x   &&
+               y   == r.y   &&
+               pc  == r.pc  &&
+               p.n == r.p.n &&
+               p.u == r.p.u &&
+               p.v == r.p.v &&
+               p.b == r.p.b &&
+               p.d == r.p.d &&
+               p.i == r.p.i &&
+               p.z == r.p.z &&
+               p.c == r.p.c;
+    }
 };
 
 }

--- a/lib/nes/include/nes/cpu/registers.h
+++ b/lib/nes/include/nes/cpu/registers.h
@@ -1,0 +1,42 @@
+#pragma once
+#include <stdint.h>
+
+namespace nes::cpu
+{
+
+struct ProcessorStatusRegister
+{
+public:
+    // Negative (1 = negative)
+    bool n : 1;
+    // Overflow 1 = true
+    bool v : 2;
+    // BRK command
+    bool b : 1;
+    // Decimal Mode 1 = true (not used for the NES)
+    bool d : 1;
+    // IRQ disable 1 = disabled
+    bool i : 1;
+    // Zero 1 = result zero
+    bool z : 1;
+    // Carry 1 = true
+    bool c : 1;
+};
+
+struct Registers
+{
+    // Accumulator
+    uint8_t a;
+    // Index register y
+    uint8_t x;
+    // Index register y
+    uint8_t y;
+    // 16 bits program counter (pch, pcl)
+    uint16_t pc;
+    // 9 bits stack pointer
+    uint16_t sp;
+    // Processor status register
+    ProcessorStatusRegister p;
+};
+
+}

--- a/lib/nes/include/nes/cpu/registers.h
+++ b/lib/nes/include/nes/cpu/registers.h
@@ -35,8 +35,8 @@ struct Registers
     uint8_t y;
     // 16 bits program counter (pch, pcl)
     uint16_t pc;
-    // 9 bits stack pointer
-    uint16_t sp;
+    // 8 bits stack pointer, wraps around. no stack overflow detection.
+    uint8_t sp;
     // Processor status register
     ProcessorStatusRegister p;
 

--- a/lib/nes/src/nes/cpu/bus/bus.cpp
+++ b/lib/nes/src/nes/cpu/bus/bus.cpp
@@ -1,6 +1,6 @@
-#include "nes/bus/bus.h"
+#include <nes/cpu/bus/bus.h>
 
-namespace nes::bus
+namespace nes::cpu::bus
 {
 
 Bus::Bus()

--- a/lib/nes/src/nes/cpu/instructions/base_instruction.cpp
+++ b/lib/nes/src/nes/cpu/instructions/base_instruction.cpp
@@ -185,6 +185,26 @@ namespace nes::cpu::instructions
         setNZ(registers, reg - memory);
     }
 
+    uint8_t BaseInstruction::branch(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, bool doBranch)
+    {
+        uint8_t ticks = 2;
+
+        if(doBranch)
+        {
+            ticks++;
+
+            int8_t offset = static_cast<int8_t>(bus.read(registers.pc + 1));
+            uint16_t page = registers.pc  & 0xff00;
+            registers.pc += offset;
+            ticks += page != (registers.pc & 0xff00);
+        }
+        else
+        {
+            registers.pc += 2;
+        }
+
+        return ticks;
+    }
 
     uint8_t BaseInstruction::ABS(nes::cpu::Registers&   registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::ABS);   return 0; }
     uint8_t BaseInstruction::ABSX(nes::cpu::Registers&  registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::ABSX);  return 0; }

--- a/lib/nes/src/nes/cpu/instructions/base_instruction.cpp
+++ b/lib/nes/src/nes/cpu/instructions/base_instruction.cpp
@@ -33,9 +33,16 @@ namespace nes::cpu::instructions
         return ticks;
     }
 
-    void BaseInstruction::push(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t value)
+    void    BaseInstruction::push(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t value)
     {
-        
+        bus.write(0x0100 | registers.sp, value);
+        registers.sp--; // The stack starts at the end of a page, and grows towards the beginning of the page.
+    }
+
+    uint8_t BaseInstruction::pull(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+    {
+        registers.sp++; // stack pointer points towards the next 'available' space.
+        return bus.read(0x0100 | registers.sp);
     }
 
     uint8_t BaseInstruction::ABS(nes::cpu::Registers&   registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::ABS);   return 0; }

--- a/lib/nes/src/nes/cpu/instructions/base_instruction.cpp
+++ b/lib/nes/src/nes/cpu/instructions/base_instruction.cpp
@@ -3,44 +3,50 @@
 namespace nes::cpu::instructions
 {
     BaseInstruction::BaseInstruction(std::string&& name, IInstructionErrorHandler& instructionErrorHandler)
-        :  _name(name), _handler(instructionErrorHandler)
+        :  _name(name), _mode(AddressingMode::UNK), _handler(instructionErrorHandler)
     {
     }
 
-    uint8_t BaseInstruction::execute(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, AddressingMode mode)
+    uint8_t BaseInstruction::execute(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
     {
         uint8_t ticks = 0;
-        switch(mode)
+        switch(_mode)
         {
-            case AddressingMode::ZeroPage:        ticks = ZeroPage(registers, bus);        break;
-            case AddressingMode::IndexedZeroPage: ticks = IndexedZeroPage(registers, bus); break;
-            case AddressingMode::Absolute:        ticks = Absolute(registers, bus);        break;
-            case AddressingMode::IndexedAbsolute: ticks = IndexedAbsolute(registers, bus); break;
-            case AddressingMode::Indirect:        ticks = Indirect(registers, bus);        break;
-            case AddressingMode::Implied:         ticks = Implied(registers, bus);         break;
-            case AddressingMode::Accumulator:     ticks = Accumulator(registers, bus);     break;
-            case AddressingMode::Immediate:       ticks = Immediate(registers, bus);       break;
-            case AddressingMode::Relative:        ticks = Relative(registers, bus);        break;
-            case AddressingMode::IndexedIndirect: ticks = IndexedIndirect(registers, bus); break;
-            case AddressingMode::IndirectIndexed: ticks = IndirectIndexed(registers, bus); break;
-            case AddressingMode::Unknown:         ticks = Unknown(registers, bus);         break;
+            case AddressingMode::ABS:   ticks = ABS(registers,   bus); break;
+            case AddressingMode::ABSX:  ticks = ABSX(registers,  bus); break;
+            case AddressingMode::ABSY:  ticks = ABSY(registers,  bus); break;
+            case AddressingMode::ACC:   ticks = ACC(registers,   bus); break;
+            case AddressingMode::IABS:  ticks = IABS(registers,  bus); break;
+            case AddressingMode::IABSX: ticks = IABSX(registers, bus); break;
+            case AddressingMode::IIND:  ticks = IIND(registers,  bus); break;
+            case AddressingMode::IINDX: ticks = IINDX(registers, bus); break;
+            case AddressingMode::IINDY: ticks = IINDY(registers, bus); break;
+            case AddressingMode::IMM:   ticks = IMM(registers,   bus); break;
+            case AddressingMode::IMP:   ticks = IMP(registers,   bus); break;
+            case AddressingMode::REL:   ticks = REL(registers,   bus); break;
+            case AddressingMode::UNK:   ticks = UNK(registers,   bus); break;
+            case AddressingMode::ZP:    ticks = ZP(registers,    bus); break;
+            case AddressingMode::ZPX:   ticks = ZPX(registers,   bus); break;
+            case AddressingMode::ZPY:   ticks = ZPY(registers,   bus); break;
         }
 
         return ticks;
     }
 
-    // TODO: call the error handler for unsupported instruction mode use.
-    uint8_t BaseInstruction::ZeroPage(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)        { _handler.invalidMode(*this, AddressingMode::ZeroPage);        return 0; }
-    uint8_t BaseInstruction::IndexedZeroPage(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::IndexedZeroPage); return 0; }
-    uint8_t BaseInstruction::Absolute(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)        { _handler.invalidMode(*this, AddressingMode::Absolute);        return 0; }
-    uint8_t BaseInstruction::IndexedAbsolute(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::IndexedAbsolute); return 0; }
-    uint8_t BaseInstruction::Indirect(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)        { _handler.invalidMode(*this, AddressingMode::Indirect);        return 0; }
-    uint8_t BaseInstruction::Implied(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)         { _handler.invalidMode(*this, AddressingMode::Implied);         return 0; }
-    uint8_t BaseInstruction::Accumulator(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)     { _handler.invalidMode(*this, AddressingMode::Accumulator);     return 0; }
-    uint8_t BaseInstruction::Immediate(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)       { _handler.invalidMode(*this, AddressingMode::Immediate);       return 0; }
-    uint8_t BaseInstruction::Relative(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)        { _handler.invalidMode(*this, AddressingMode::Relative);        return 0; }
-    uint8_t BaseInstruction::IndexedIndirect(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::IndexedIndirect); return 0; }
-    uint8_t BaseInstruction::IndirectIndexed(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::IndirectIndexed); return 0; }
-    uint8_t BaseInstruction::Unknown(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)         { _handler.invalidMode(*this, AddressingMode::Unknown);         return 0; }
-
+    uint8_t BaseInstruction::ABS(nes::cpu::Registers&   registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::ABS);   return 0; }
+    uint8_t BaseInstruction::ABSX(nes::cpu::Registers&  registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::ABSX);  return 0; }
+    uint8_t BaseInstruction::ABSY(nes::cpu::Registers&  registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::ABSY);  return 0; }
+    uint8_t BaseInstruction::ACC(nes::cpu::Registers&   registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::ACC);   return 0; }
+    uint8_t BaseInstruction::IABS(nes::cpu::Registers&  registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::IABS);  return 0; }
+    uint8_t BaseInstruction::IABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::IABSX); return 0; }
+    uint8_t BaseInstruction::IIND(nes::cpu::Registers&  registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::IIND);  return 0; }
+    uint8_t BaseInstruction::IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::IINDX); return 0; }
+    uint8_t BaseInstruction::IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::IINDY); return 0; }
+    uint8_t BaseInstruction::IMM(nes::cpu::Registers&   registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::IMM);   return 0; }
+    uint8_t BaseInstruction::IMP(nes::cpu::Registers&   registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::IMP);   return 0; }
+    uint8_t BaseInstruction::REL(nes::cpu::Registers&   registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::REL);   return 0; }
+    uint8_t BaseInstruction::UNK(nes::cpu::Registers&   registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::UNK);   return 0; }
+    uint8_t BaseInstruction::ZP(nes::cpu::Registers&    registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::ZP);    return 0; }
+    uint8_t BaseInstruction::ZPX(nes::cpu::Registers&   registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::ZPX);   return 0; }
+    uint8_t BaseInstruction::ZPY(nes::cpu::Registers&   registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::ZPY);   return 0; }
 }

--- a/lib/nes/src/nes/cpu/instructions/base_instruction.cpp
+++ b/lib/nes/src/nes/cpu/instructions/base_instruction.cpp
@@ -23,6 +23,7 @@ namespace nes::cpu::instructions
             case AddressingMode::Relative:        ticks = Relative(registers, bus);        break;
             case AddressingMode::IndexedIndirect: ticks = IndexedIndirect(registers, bus); break;
             case AddressingMode::IndirectIndexed: ticks = IndirectIndexed(registers, bus); break;
+            case AddressingMode::Unknown:         ticks = Unknown(registers, bus);         break;
         }
 
         return ticks;
@@ -40,6 +41,6 @@ namespace nes::cpu::instructions
     uint8_t BaseInstruction::Relative(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)        { _handler.invalidMode(*this, AddressingMode::Relative);        return 0; }
     uint8_t BaseInstruction::IndexedIndirect(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::IndexedIndirect); return 0; }
     uint8_t BaseInstruction::IndirectIndexed(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::IndirectIndexed); return 0; }
-
+    uint8_t BaseInstruction::Unknown(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)         { _handler.invalidMode(*this, AddressingMode::Unknown);         return 0; }
 
 }

--- a/lib/nes/src/nes/cpu/instructions/base_instruction.cpp
+++ b/lib/nes/src/nes/cpu/instructions/base_instruction.cpp
@@ -33,6 +33,11 @@ namespace nes::cpu::instructions
         return ticks;
     }
 
+    void BaseInstruction::push(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, uint8_t value)
+    {
+        
+    }
+
     uint8_t BaseInstruction::ABS(nes::cpu::Registers&   registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::ABS);   return 0; }
     uint8_t BaseInstruction::ABSX(nes::cpu::Registers&  registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::ABSX);  return 0; }
     uint8_t BaseInstruction::ABSY(nes::cpu::Registers&  registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::ABSY);  return 0; }

--- a/lib/nes/src/nes/cpu/instructions/base_instruction.cpp
+++ b/lib/nes/src/nes/cpu/instructions/base_instruction.cpp
@@ -1,0 +1,45 @@
+#include <nes/cpu/instructions/base_instruction.h>
+
+namespace nes::cpu::instructions
+{
+    BaseInstruction::BaseInstruction(std::string&& name, IInstructionErrorHandler& instructionErrorHandler)
+        :  _name(name), _handler(instructionErrorHandler)
+    {
+    }
+
+    uint8_t BaseInstruction::execute(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus, AddressingMode mode)
+    {
+        uint8_t ticks = 0;
+        switch(mode)
+        {
+            case AddressingMode::ZeroPage:        ticks = ZeroPage(registers, bus);        break;
+            case AddressingMode::IndexedZeroPage: ticks = IndexedZeroPage(registers, bus); break;
+            case AddressingMode::Absolute:        ticks = Absolute(registers, bus);        break;
+            case AddressingMode::IndexedAbsolute: ticks = IndexedAbsolute(registers, bus); break;
+            case AddressingMode::Indirect:        ticks = Indirect(registers, bus);        break;
+            case AddressingMode::Implied:         ticks = Implied(registers, bus);         break;
+            case AddressingMode::Accumulator:     ticks = Accumulator(registers, bus);     break;
+            case AddressingMode::Immediate:       ticks = Immediate(registers, bus);       break;
+            case AddressingMode::Relative:        ticks = Relative(registers, bus);        break;
+            case AddressingMode::IndexedIndirect: ticks = IndexedIndirect(registers, bus); break;
+            case AddressingMode::IndirectIndexed: ticks = IndirectIndexed(registers, bus); break;
+        }
+
+        return ticks;
+    }
+
+    // TODO: call the error handler for unsupported instruction mode use.
+    uint8_t BaseInstruction::ZeroPage(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)        { _handler.invalidMode(*this, AddressingMode::ZeroPage);        return 0; }
+    uint8_t BaseInstruction::IndexedZeroPage(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::IndexedZeroPage); return 0; }
+    uint8_t BaseInstruction::Absolute(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)        { _handler.invalidMode(*this, AddressingMode::Absolute);        return 0; }
+    uint8_t BaseInstruction::IndexedAbsolute(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::IndexedAbsolute); return 0; }
+    uint8_t BaseInstruction::Indirect(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)        { _handler.invalidMode(*this, AddressingMode::Indirect);        return 0; }
+    uint8_t BaseInstruction::Implied(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)         { _handler.invalidMode(*this, AddressingMode::Implied);         return 0; }
+    uint8_t BaseInstruction::Accumulator(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)     { _handler.invalidMode(*this, AddressingMode::Accumulator);     return 0; }
+    uint8_t BaseInstruction::Immediate(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)       { _handler.invalidMode(*this, AddressingMode::Immediate);       return 0; }
+    uint8_t BaseInstruction::Relative(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)        { _handler.invalidMode(*this, AddressingMode::Relative);        return 0; }
+    uint8_t BaseInstruction::IndexedIndirect(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::IndexedIndirect); return 0; }
+    uint8_t BaseInstruction::IndirectIndexed(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { _handler.invalidMode(*this, AddressingMode::IndirectIndexed); return 0; }
+
+
+}

--- a/lib/nes/src/nes/cpu/instructions/instruction_decoder.cpp
+++ b/lib/nes/src/nes/cpu/instructions/instruction_decoder.cpp
@@ -1,6 +1,8 @@
 #include <nes/cpu/instructions/instruction_decoder.h>
 
-namespace nes::instructions
+namespace nes::cpu::instructions
 {
+
+    
 
 }

--- a/lib/nes/src/nes/cpu/instructions/instruction_decoder.cpp
+++ b/lib/nes/src/nes/cpu/instructions/instruction_decoder.cpp
@@ -1,0 +1,6 @@
+#include <nes/cpu/instructions/instruction_decoder.h>
+
+namespace nes::instructions
+{
+
+}

--- a/lib/nes/src/nes/cpu/instructions/instructions.cpp
+++ b/lib/nes/src/nes/cpu/instructions/instructions.cpp
@@ -1,0 +1,289 @@
+#include <nes/cpu/instructions/instructions.h>
+
+namespace nes::cpu::instructions
+{
+// constructors
+ADSInstruction::ADSInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("ADS", handler) {}
+ANDInstruction::ANDInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("AND", handler) {}
+ASLInstruction::ASLInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("ASL", handler) {}
+BCCInstruction::BCCInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("BCC", handler) {}
+BCSInstruction::BCSInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("BCS", handler) {}
+BEQInstruction::BEQInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("BEQ", handler) {}
+BITInstruction::BITInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("BIT", handler) {}
+BMIInstruction::BMIInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("BMI", handler) {}
+BNEInstruction::BNEInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("BNE", handler) {}
+BPLInstruction::BPLInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("BPL", handler) {}
+BRKInstruction::BRKInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("BRK", handler) {}
+BVCInstruction::BVCInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("BVC", handler) {}
+BVSInstruction::BVSInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("BVS", handler) {}
+CLCInstruction::CLCInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("CLC", handler) {}
+CLDInstruction::CLDInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("CLD", handler) {}
+CLIInstruction::CLIInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("CLI", handler) {}
+CLVInstruction::CLVInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("CLV", handler) {}
+CMPInstruction::CMPInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("CMP", handler) {}
+CPXInstruction::CPXInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("CPX", handler) {}
+CPYInstruction::CPYInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("CPY", handler) {}
+DECInstruction::DECInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("DEC", handler) {}
+DEXInstruction::DEXInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("DEX", handler) {}
+DEYInstruction::DEYInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("DEY", handler) {}
+EORInstruction::EORInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("EOR", handler) {}
+INCInstruction::INCInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("INC", handler) {}
+INXInstruction::INXInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("INX", handler) {}
+INYInstruction::INYInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("INY", handler) {}
+JMPInstruction::JMPInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("JMP", handler) {}
+JSRInstruction::JSRInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("JSR", handler) {}
+LDAInstruction::LDAInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("LDA", handler) {}
+LDXInstruction::LDXInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("LDX", handler) {}
+LDYInstruction::LDYInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("LDY", handler) {}
+LSRInstruction::LSRInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("LSR", handler) {}
+NOPInstruction::NOPInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("NOP", handler) {}
+ORAInstruction::ORAInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("ORA", handler) {}
+PHAInstruction::PHAInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("PHA", handler) {}
+PHPInstruction::PHPInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("PHP", handler) {}
+PLAInstruction::PLAInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("PLA", handler) {}
+PLPInstruction::PLPInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("PLP", handler) {}
+ROLInstruction::ROLInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("ROL", handler) {}
+RORInstruction::RORInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("ROR", handler) {}
+RTIInstruction::RTIInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("RTI", handler) {}
+RTSInstruction::RTSInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("RTS", handler) {}
+SBCInstruction::SBCInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("SBC", handler) {}
+SECInstruction::SECInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("SEC", handler) {}
+SEDInstruction::SEDInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("SED", handler) {}
+SEIInstruction::SEIInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("SEI", handler) {}
+STAInstruction::STAInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("STA", handler) {}
+STXInstruction::STXInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("STX", handler) {}
+STYInstruction::STYInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("STY", handler) {}
+TAXInstruction::TAXInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("TAX", handler) {}
+TAYInstruction::TAYInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("TAY", handler) {}
+TSXInstruction::TSXInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("TSX", handler) {}
+TXAInstruction::TXAInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("TXA", handler) {}
+TXSInstruction::TXSInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("TXS", handler) {}
+TYAInstruction::TYAInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("TYA", handler) {}
+
+
+//
+// ADS OpCodes
+//
+
+//
+// AND OpCodes
+//
+
+//
+// ASL OpCodes
+//
+
+//
+// BCC OpCodes
+//
+
+//
+// BCS OpCodes
+//
+
+//
+// BEQ OpCodes
+//
+
+//
+// BIT OpCodes
+//
+
+//
+// BMI OpCodes
+//
+
+//
+// BNE OpCodes
+//
+
+//
+// BPL OpCodes
+//
+
+//
+// BRK OpCodes
+//
+
+//
+// BVC OpCodes
+//
+
+//
+// BVS OpCodes
+//
+
+//
+// CLC OpCodes
+//
+
+//
+// CLD OpCodes
+//
+
+//
+// CLI OpCodes
+//
+
+//
+// CLV OpCodes
+//
+
+//
+// CMP OpCodes
+//
+
+//
+// CPX OpCodes
+//
+
+//
+// CPY OpCodes
+//
+
+//
+// DEC OpCodes
+//
+
+//
+// DEX OpCodes
+//
+
+//
+// DEY OpCodes
+//
+
+//
+// EOR OpCodes
+//
+
+//
+// INC OpCodes
+//
+
+//
+// INX OpCodes
+//
+
+//
+// INY OpCodes
+//
+
+//
+// JMP OpCodes
+//
+
+//
+// JSR OpCodes
+//
+
+//
+// LDA OpCodes
+//
+
+//
+// LDX OpCodes
+//
+
+//
+// LDY OpCodes
+//
+
+//
+// LSR OpCodes
+//
+
+//
+// NOP OpCodes
+//
+
+//
+// ORA OpCodes
+//
+
+//
+// PHA OpCodes
+//
+
+//
+// PHP OpCodes
+//
+
+//
+// PLA OpCodes
+//
+
+//
+// PLP OpCodes
+//
+
+//
+// ROL OpCodes
+//
+
+//
+// ROR OpCodes
+//
+
+//
+// RTI OpCodes
+//
+
+//
+// RTS OpCodes
+//
+
+//
+// SBC OpCodes
+//
+
+//
+// SEC OpCodes
+//
+
+//
+// SED OpCodes
+//
+
+//
+// SEI OpCodes
+//
+
+//
+// STA OpCodes
+//
+
+//
+// STX OpCodes
+//
+
+//
+// STY OpCodes
+//
+
+//
+// TAX OpCodes
+//
+
+//
+// TAY OpCodes
+//
+
+//
+// TSX OpCodes
+//
+
+//
+// TXA OpCodes
+//
+
+//
+// TXS OpCodes
+//
+
+//
+// TYA OpCodes
+//
+
+
+}

--- a/lib/nes/src/nes/cpu/instructions/instructions.cpp
+++ b/lib/nes/src/nes/cpu/instructions/instructions.cpp
@@ -85,7 +85,16 @@ uint8_t ORAInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus
 //
 
 uint8_t ASLInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t ASLInstruction::ACC(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ASLInstruction::ACC(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    registers.pc++;
+    registers.p.c = (registers.a & 0x80) > 0;
+    registers.a <<= 1;
+    registers.p.n = (registers.a & 0x80) > 0;
+    registers.p.z = registers.a == 0;
+    return 2;
+}
+
 uint8_t ASLInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 uint8_t ASLInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 uint8_t ASLInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
@@ -106,7 +115,12 @@ uint8_t BPLInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 // CLC
 //
 
-uint8_t CLCInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t CLCInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) 
+{
+    registers.pc++;
+    registers.p.c = false;
+    return 2;
+}       
 
 //
 // JSR
@@ -139,7 +153,18 @@ uint8_t BITInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 //
 
 uint8_t ROLInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t ROLInstruction::ACC(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ROLInstruction::ACC(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    auto carry = registers.p.c;
+    registers.pc++;
+    registers.p.c = (registers.a & 0x80) > 0;
+    registers.a <<= 1;
+    registers.a |= carry;
+    registers.p.z = registers.a == 0;
+    registers.p.n = (registers.a & 0x80) > 0;
+    return 2;
+}
+
 uint8_t ROLInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 uint8_t ROLInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 uint8_t ROLInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
@@ -160,7 +185,12 @@ uint8_t BMIInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 // SEC
 //
 
-uint8_t SECInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t SECInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    registers.pc++;
+    registers.p.c = true;
+    return 2;
+}     
 
 //
 // RTI
@@ -186,7 +216,16 @@ uint8_t EORInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus
 //
 
 uint8_t LSRInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t LSRInstruction::ACC(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t LSRInstruction::ACC(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    registers.pc++;
+    registers.p.c = registers.a & 1;
+    registers.a >>= 1;
+    registers.p.z = registers.a == 0;
+    registers.p.n = (registers.a & 0x80) > 0; // do we really need this? this should never be possible.
+    return 2;    
+}
+
 uint8_t LSRInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 uint8_t LSRInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 uint8_t LSRInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
@@ -214,7 +253,12 @@ uint8_t BVCInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 // CLI
 //
 
-uint8_t CLIInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t CLIInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) 
+{
+    registers.pc++;
+    registers.p.i = false;
+    return 2; 
+}
 
 //
 // RTS
@@ -261,7 +305,12 @@ uint8_t BVSInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 // SEI
 //
 
-uint8_t SEIInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t SEIInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) 
+{
+    registers.pc++;
+    registers.p.i = true;
+    return 2; 
+}
 
 //
 // STA
@@ -295,13 +344,27 @@ uint8_t STXInstruction::ZPY(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 // DEY
 //
 
-uint8_t DEYInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t DEYInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    registers.pc++;
+    registers.y--;
+    registers.p.z = registers.y == 0;
+    registers.p.n = (registers.y & 0x80) > 0;
+    return 2;
+}     
 
 //
 // TXA
 //
 
-uint8_t TXAInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t TXAInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    registers.pc++;
+    registers.a = registers.x;
+    registers.p.z = registers.a == 0;
+    registers.p.n = (registers.a & 0x80) > 0;
+    return 2;
+}
 
 //
 // BCC
@@ -313,7 +376,14 @@ uint8_t BCCInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 // TYA
 //
 
-uint8_t TYAInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t TYAInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    registers.pc++;
+    registers.a = registers.y;
+    registers.p.z = registers.a == 0;
+    registers.p.n = (registers.a & 0x80) > 0;
+    return 2;
+}
 
 //
 // TXS
@@ -358,13 +428,27 @@ uint8_t LDXInstruction::ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus
 // TAY
 //
 
-uint8_t TAYInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t TAYInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    registers.pc++;
+    registers.y = registers.a;
+    registers.p.z = registers.y == 0;
+    registers.p.n = (registers.y & 0x80) > 0;
+    return 2;
+}
 
 //
 // TAX
 //
 
-uint8_t TAXInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t TAXInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    registers.pc++;
+    registers.x   = registers.a;
+    registers.p.z = registers.x == 0;
+    registers.p.n = (registers.x & 0x80) > 0;
+    return 2;
+}
 
 //
 // BCS
@@ -376,13 +460,25 @@ uint8_t BCSInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 // CLV
 //
 
-uint8_t CLVInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t CLVInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) 
+{
+    registers.pc++;
+    registers.p.v = false;
+    return 2; 
+}
 
 //
 // TSX
 //
 
-uint8_t TSXInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t TSXInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    registers.pc++;
+    registers.x = registers.sp;
+    registers.p.n = (registers.x & 0x80) > 0;
+    registers.p.z = registers.x == 0;
+    return 2;
+}
 
 //
 // CPY
@@ -418,13 +514,27 @@ uint8_t DECInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus
 // INY
 //
 
-uint8_t INYInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t INYInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    registers.pc++;
+    registers.y++;
+    registers.p.z = registers.y == 0;
+    registers.p.n = (registers.y & 0x80) > 0;
+    return 2;
+}
 
 //
 // DEX
 //
 
-uint8_t DEXInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t DEXInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) 
+{
+    registers.pc++;
+    registers.x--;
+    registers.p.z = registers.x == 0;
+    registers.p.n = (registers.x & 0x80) > 0;
+    return 2;
+}
 
 //
 // BNE
@@ -436,7 +546,12 @@ uint8_t BNEInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 // CLD
 //
 
-uint8_t CLDInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t CLDInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) 
+{ 
+    registers.pc++;
+    registers.p.d = false;
+    return 2; 
+}
 
 //
 // CPX
@@ -472,13 +587,24 @@ uint8_t INCInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus
 // INX
 //
 
-uint8_t INXInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t INXInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) 
+{
+    registers.pc++;
+    registers.x++;
+    registers.p.z = registers.x == 0;
+    registers.p.n = (registers.x & 0x80) > 0;
+    return 2;
+}
 
 //
 // NOP
 //
 
-uint8_t NOPInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t NOPInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) 
+{ 
+    registers.pc++;
+    return 1; 
+}
 
 //
 // BEQ
@@ -490,6 +616,11 @@ uint8_t BEQInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 // SED
 //
 
-uint8_t SEDInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t SEDInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    registers.pc++;
+    registers.p.d = true;
+    return 2;
+}
 
 }

--- a/lib/nes/src/nes/cpu/instructions/instructions.cpp
+++ b/lib/nes/src/nes/cpu/instructions/instructions.cpp
@@ -867,7 +867,10 @@ uint8_t PLAInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 // BVS
 //
 
-uint8_t BVSInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t BVSInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return branch(registers, bus, registers.p.v);
+}
 
 //
 // SEI
@@ -989,7 +992,10 @@ uint8_t TXAInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 // BCC
 //
 
-uint8_t BCCInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t BCCInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return branch(registers, bus, !registers.p.c);
+}
 
 //
 // TYA
@@ -1155,7 +1161,10 @@ uint8_t TAXInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 // BCS
 //
 
-uint8_t BCSInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t BCSInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return branch(registers, bus, registers.p.c);
+}
 
 //
 // CLV
@@ -1352,7 +1361,10 @@ uint8_t DEXInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 // BNE
 //
 
-uint8_t BNEInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t BNEInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return branch(registers, bus, !registers.p.z);
+}
 
 //
 // CLD
@@ -1532,7 +1544,10 @@ uint8_t NOPInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 // BEQ
 //
 
-uint8_t BEQInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t BEQInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return branch(registers, bus, registers.p.z);
+}
 
 //
 // SED

--- a/lib/nes/src/nes/cpu/instructions/instructions.cpp
+++ b/lib/nes/src/nes/cpu/instructions/instructions.cpp
@@ -3,7 +3,7 @@
 namespace nes::cpu::instructions
 {
 // constructors
-ADSInstruction::ADSInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("ADS", handler) {}
+ADCInstruction::ADCInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("ADC", handler) {}
 ANDInstruction::ANDInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("AND", handler) {}
 ASLInstruction::ASLInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("ASL", handler) {}
 BCCInstruction::BCCInstruction(IInstructionErrorHandler& handler) : BaseInstruction::BaseInstruction("BCC", handler) {}

--- a/lib/nes/src/nes/cpu/instructions/instructions.cpp
+++ b/lib/nes/src/nes/cpu/instructions/instructions.cpp
@@ -85,7 +85,7 @@ uint8_t BRKInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 
 uint8_t ORAInstruction::IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
 { 
-    registers.a |= indirectX(registers, bus);
+    registers.a |= bus.read(indirectXAddr(registers, bus));
 
     registers.pc += 2;
     setNZ(registers, registers.a);
@@ -119,7 +119,7 @@ uint8_t ORAInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 uint8_t ORAInstruction::IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
 { 
     bool pageCrossed;
-    registers.a |= indirectY(registers, bus, pageCrossed);
+    registers.a |= bus.read(indirectYAddr(registers, bus, pageCrossed));
     registers.pc += 2;
     setNZ(registers, registers.a);
     return 5 + pageCrossed; 
@@ -127,7 +127,7 @@ uint8_t ORAInstruction::IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBu
 
 uint8_t ORAInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
 {
-    registers.a |= bus.read(getZeroPageXAddr(registers, bus));
+    registers.a |= bus.read(getZeroPageXYAddr(registers, bus, registers.x));
     registers.pc +=2;
     setNZ(registers, registers.a);
     return 4;
@@ -189,7 +189,7 @@ uint8_t ASLInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 }
 uint8_t ASLInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
 {
-    auto ptr = getZeroPageXAddr(registers, bus);
+    auto ptr = getZeroPageXYAddr(registers, bus, registers.x);
     auto value = bus.read(ptr);
     registers.p.c = (value & 0x80) > 0;
     value <<= 1;
@@ -271,7 +271,7 @@ uint8_t JSRInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 
 uint8_t ANDInstruction::IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
 {
-    registers.a &= indirectX(registers, bus);
+    registers.a &= bus.read(indirectXAddr(registers, bus));
 
     registers.pc += 2;
     setNZ(registers, registers.a);
@@ -303,14 +303,14 @@ uint8_t ANDInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 uint8_t ANDInstruction::IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
 {
     bool pageCrossed;
-    registers.a &= indirectY(registers, bus, pageCrossed);
+    registers.a &= bus.read(indirectYAddr(registers, bus, pageCrossed));
     registers.pc += 2;
     setNZ(registers, registers.a);
     return 5 + pageCrossed; 
 }
 uint8_t ANDInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
 {
-    registers.a &= bus.read(getZeroPageXAddr(registers, bus));
+    registers.a &= bus.read(getZeroPageXYAddr(registers, bus, registers.x));
     setNZ(registers, registers.a);
     registers.pc += 2;
     return 2; 
@@ -358,7 +358,21 @@ uint8_t BITInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 // ROL
 //
 
-uint8_t ROLInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ROLInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    auto carry = registers.p.c;
+    auto ptr   = bus.read(registers.pc + 1);
+    auto value = bus.read(ptr);
+
+    registers.pc += 2;
+    registers.p.c = (value & 0x80) > 0;
+    value <<= 1;
+    value |= carry;
+    setNZ(registers, value);
+    bus.write(ptr, value);
+    return 5;
+}
+
 uint8_t ROLInstruction::ACC(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
 {
     auto carry = registers.p.c;
@@ -366,14 +380,55 @@ uint8_t ROLInstruction::ACC(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
     registers.p.c = (registers.a & 0x80) > 0;
     registers.a <<= 1;
     registers.a |= carry;
-    registers.p.z = registers.a == 0;
-    registers.p.n = (registers.a & 0x80) > 0;
+    setNZ(registers, registers.a);
     return 2;
 }
 
-uint8_t ROLInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t ROLInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t ROLInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ROLInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    auto carry = registers.p.c;
+    auto ptr   = read16(bus, registers.pc +1);
+    auto value = bus.read(ptr);
+
+    registers.pc += 3;
+    registers.p.c = (value & 0x80) > 0;
+    value <<= 1;
+    value |= carry;
+    setNZ(registers, value);
+    bus.write(ptr, value);
+    return 6;
+}
+
+uint8_t ROLInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    auto carry = registers.p.c;
+    auto ptr = getZeroPageXYAddr(registers, bus, registers.x);
+    auto value = bus.read(ptr);
+
+    registers.pc += 2;
+    registers.p.c = (value & 0x80) > 0;
+    value <<= 1;
+    value |= carry;
+    setNZ(registers, value);
+    bus.write(ptr, value);
+    return 6;
+}
+
+uint8_t ROLInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    auto carry = registers.p.c;
+    bool pageCrossed; // not used
+    auto ptr = getABSXYAddr(registers, bus, registers.x, pageCrossed);
+    auto value = bus.read(ptr);
+
+    registers.pc += 3;
+    registers.p.c = (value & 0x80) > 0;
+    value <<= 1;
+    value |= carry;
+    setNZ(registers, value);
+    bus.write(ptr, value);
+    return 7;
+}
 
 //
 // PLP
@@ -390,7 +445,20 @@ uint8_t PLPInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 // BMI
 //
 
-uint8_t BMIInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t BMIInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    if(!registers.p.n)
+    {
+        registers.pc +=2;
+        return 2;
+    }
+
+    auto jmp = static_cast<int8_t>(bus.read(registers.pc+1));
+    auto page = registers.pc & 0xFF00;
+    registers.pc += jmp;
+    
+    return 3 + (page != (registers.pc & 0xFF00));
+}
 
 //
 // SEC
@@ -603,29 +671,80 @@ uint8_t SEIInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 // STA
 //
 
-uint8_t STAInstruction::IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t STAInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t STAInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t STAInstruction::IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t STAInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t STAInstruction::ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t STAInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t STAInstruction::IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    bus.write(indirectXAddr(registers, bus), registers.a);
+    registers.pc += 2;
+    return 6;
+}
+uint8_t STAInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return storeZP(registers, bus, registers.a);
+}
+uint8_t STAInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return storeABS(registers, bus, registers.a);
+}
+
+uint8_t STAInstruction::IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    bool pageCrossed;
+    bus.write(indirectYAddr(registers, bus, pageCrossed), registers.a);
+    registers.pc += 2;
+    return 6;
+}
+uint8_t STAInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return storeZPXY(registers, bus, registers.a, registers.x);
+}
+
+uint8_t STAInstruction::ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return storeABSXY(registers, bus, registers.a, registers.y);
+}
+
+uint8_t STAInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return storeABSXY(registers, bus, registers.a, registers.x);
+}
 
 //
 // STY
 //
 
-uint8_t STYInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t STYInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t STYInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t STYInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return storeZP(registers, bus, registers.y);
+}
+
+uint8_t STYInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return storeABS(registers, bus, registers.y);
+}
+
+uint8_t STYInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return storeZPXY(registers, bus, registers.y, registers.x);
+}
 
 //
 // STX
 //
 
-uint8_t STXInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t STXInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t STXInstruction::ZPY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t STXInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return storeZP(registers, bus, registers.x);
+}
+
+uint8_t STXInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return storeABS(registers, bus, registers.x);
+}
+
+uint8_t STXInstruction::ZPY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return storeZPXY(registers, bus, registers.x, registers.y);
+}
 
 //
 // DEY
@@ -687,34 +806,111 @@ uint8_t TXSInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus&
 // LDY
 //
 
-uint8_t LDYInstruction::IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t LDYInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t LDYInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t LDYInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t LDYInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t LDYInstruction::IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return ldTargetImmediate(registers, bus, registers.y);
+}
+
+uint8_t LDYInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return ldTargetZeroPage(registers, bus, registers.y);
+}
+
+uint8_t LDYInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return ldTargetAbsolute(registers, bus, registers.y);
+}
+
+uint8_t LDYInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return ldTargetZeroPageXY(registers, bus, registers.y, registers.x);
+}
+
+uint8_t LDYInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return ldTargetAbsoluteXY(registers, bus, registers.y, registers.x);    
+}
 
 //
 // LDA
 //
 
-uint8_t LDAInstruction::IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t LDAInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t LDAInstruction::IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t LDAInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t LDAInstruction::IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t LDAInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t LDAInstruction::ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t LDAInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t LDAInstruction::IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    registers.a = bus.read(indirectXAddr(registers, bus));
+    setNZ(registers, registers.a);
+    registers.pc +=2;
+    return 6;
+}
+
+uint8_t LDAInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return ldTargetZeroPage(registers, bus, registers.a);
+}
+
+uint8_t LDAInstruction::IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return ldTargetImmediate(registers, bus, registers.a);
+}
+
+uint8_t LDAInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return ldTargetAbsolute(registers, bus, registers.a);
+}
+
+uint8_t LDAInstruction::IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    bool pageCrossed;
+    registers.a = bus.read(indirectYAddr(registers, bus, pageCrossed));
+    setNZ(registers, registers.a);
+    registers.pc += 2;
+    return 5 + pageCrossed;
+}
+
+uint8_t LDAInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return ldTargetZeroPageXY(registers, bus, registers.a, registers.x);
+}
+
+uint8_t LDAInstruction::ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return ldTargetAbsoluteXY(registers, bus, registers.a, registers.y);
+}
+
+uint8_t LDAInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return ldTargetAbsoluteXY(registers, bus, registers.a, registers.x);
+}
+
 
 //
 // LDX
 //
 
-uint8_t LDXInstruction::IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t LDXInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t LDXInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t LDXInstruction::ZPY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t LDXInstruction::ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t LDXInstruction::IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return ldTargetImmediate(registers, bus, registers.x);
+}
+
+uint8_t LDXInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return ldTargetZeroPage(registers, bus, registers.x);
+}
+
+uint8_t LDXInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return ldTargetAbsolute(registers, bus, registers.x);
+}
+
+uint8_t LDXInstruction::ZPY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return ldTargetZeroPageXY(registers, bus, registers.x, registers.y);
+}
+
+uint8_t LDXInstruction::ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    return ldTargetAbsoluteXY(registers, bus, registers.x, registers.y);
+}
 
 //
 // TAY
@@ -797,10 +993,54 @@ uint8_t CMPInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus
 // DEC
 //
 
-uint8_t DECInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t DECInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t DECInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t DECInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t DECInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    auto ptr = bus.read(registers.pc + 1);
+    auto value = bus.read(ptr);
+    value--;
+    bus.write(ptr, value);
+
+    setNZ(registers, value);
+    registers.pc += 2;
+    return 5;
+}
+
+uint8_t DECInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    auto ptr = read16(bus, registers.pc + 1);
+    auto value = bus.read(ptr);
+    value--;
+    bus.write(ptr, value);
+
+    setNZ(registers, value);
+    registers.pc += 3;
+    return 6;
+}
+
+uint8_t DECInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    auto ptr = getZeroPageXYAddr(registers, bus, registers.x);
+    auto value = bus.read(ptr);
+    value--;
+    bus.write(ptr, value);
+
+    setNZ(registers, value);
+    registers.pc += 2;
+    return 6;
+}
+
+uint8_t DECInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    bool pageCrossed; // not used
+    auto ptr = getABSXYAddr(registers, bus, registers.x, pageCrossed);
+    auto value = bus.read(ptr);
+    value--;
+    bus.write(ptr, value);
+
+    setNZ(registers, value);
+    registers.pc += 3;
+    return 7;
+} 
 
 //
 // INY
@@ -870,10 +1110,54 @@ uint8_t SBCInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus
 // INC
 //
 
-uint8_t INCInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t INCInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t INCInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
-uint8_t INCInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t INCInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    auto ptr = bus.read(registers.pc + 1);
+    auto value = bus.read(ptr);
+    value++;
+    bus.write(ptr, value);
+
+    setNZ(registers, value);
+    registers.pc += 2;
+    return 5;
+}
+
+uint8_t INCInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    auto ptr = read16(bus, registers.pc + 1);
+    auto value = bus.read(ptr);
+    value++;
+    bus.write(ptr, value);
+
+    setNZ(registers, value);
+    registers.pc += 3;
+    return 6;
+}
+
+uint8_t INCInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    auto ptr = getZeroPageXYAddr(registers, bus, registers.x);
+    auto value = bus.read(ptr);
+    value++;
+    bus.write(ptr, value);
+
+    setNZ(registers, value);
+    registers.pc += 2;
+    return 6;
+}
+
+uint8_t INCInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus)
+{
+    bool pageCrossed; // not used
+    auto ptr = getABSXYAddr(registers, bus, registers.x, pageCrossed);
+    auto value = bus.read(ptr);
+    value++;
+    bus.write(ptr, value);
+
+    setNZ(registers, value);
+    registers.pc += 3;
+    return 7;
+}
 
 //
 // INX

--- a/lib/nes/src/nes/cpu/instructions/instructions.cpp
+++ b/lib/nes/src/nes/cpu/instructions/instructions.cpp
@@ -62,228 +62,434 @@ TYAInstruction::TYAInstruction(IInstructionErrorHandler& handler) : BaseInstruct
 
 
 //
-// ADS OpCodes
+// BRK
 //
 
-//
-// AND OpCodes
-//
+uint8_t BRKInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// ASL OpCodes
+// ORA
 //
 
-//
-// BCC OpCodes
-//
+uint8_t ORAInstruction::IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ORAInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ORAInstruction::IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ORAInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ORAInstruction::IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ORAInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ORAInstruction::ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ORAInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// BCS OpCodes
+// ASL
 //
 
-//
-// BEQ OpCodes
-//
+uint8_t ASLInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ASLInstruction::ACC(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ASLInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ASLInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ASLInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// BIT OpCodes
+// PHP
 //
 
-//
-// BMI OpCodes
-//
+uint8_t PHPInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// BNE OpCodes
+// BPL
 //
 
-//
-// BPL OpCodes
-//
+uint8_t BPLInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// BRK OpCodes
+// CLC
 //
 
-//
-// BVC OpCodes
-//
+uint8_t CLCInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// BVS OpCodes
+// JSR
 //
 
-//
-// CLC OpCodes
-//
+uint8_t JSRInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// CLD OpCodes
+// AND
 //
 
-//
-// CLI OpCodes
-//
+uint8_t ANDInstruction::IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ANDInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ANDInstruction::IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ANDInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ANDInstruction::IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ANDInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ANDInstruction::ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ANDInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// CLV OpCodes
+// BIT
 //
 
-//
-// CMP OpCodes
-//
+uint8_t BITInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t BITInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// CPX OpCodes
+// ROL
 //
 
-//
-// CPY OpCodes
-//
+uint8_t ROLInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ROLInstruction::ACC(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ROLInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ROLInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ROLInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// DEC OpCodes
+// PLP
 //
 
-//
-// DEX OpCodes
-//
+uint8_t PLPInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// DEY OpCodes
+// BMI
 //
 
-//
-// EOR OpCodes
-//
+uint8_t BMIInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// INC OpCodes
+// SEC
 //
 
-//
-// INX OpCodes
-//
+uint8_t SECInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// INY OpCodes
+// RTI
 //
 
-//
-// JMP OpCodes
-//
+uint8_t RTIInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// JSR OpCodes
+// EOR
 //
 
-//
-// LDA OpCodes
-//
+uint8_t EORInstruction::IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t EORInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t EORInstruction::IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t EORInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t EORInstruction::IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t EORInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t EORInstruction::ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t EORInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// LDX OpCodes
+// LSR
 //
 
-//
-// LDY OpCodes
-//
+uint8_t LSRInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t LSRInstruction::ACC(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t LSRInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t LSRInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t LSRInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// LSR OpCodes
+// PHA
 //
 
-//
-// NOP OpCodes
-//
+uint8_t PHAInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// ORA OpCodes
+// JMP
 //
 
-//
-// PHA OpCodes
-//
+uint8_t JMPInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t JMPInstruction::IABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// PHP OpCodes
+// BVC
 //
 
-//
-// PLA OpCodes
-//
+uint8_t BVCInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// PLP OpCodes
+// CLI
 //
 
-//
-// ROL OpCodes
-//
+uint8_t CLIInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// ROR OpCodes
+// RTS
 //
 
-//
-// RTI OpCodes
-//
+uint8_t RTSInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// RTS OpCodes
+// ADC
 //
 
-//
-// SBC OpCodes
-//
+uint8_t ADCInstruction::IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ADCInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ADCInstruction::IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ADCInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ADCInstruction::IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ADCInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ADCInstruction::ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t ADCInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// SEC OpCodes
+// ROR
 //
 
-//
-// SED OpCodes
-//
+uint8_t RORInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t RORInstruction::ACC(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t RORInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t RORInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t RORInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// SEI OpCodes
+// PLA
 //
 
-//
-// STA OpCodes
-//
+uint8_t PLAInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// STX OpCodes
+// BVS
 //
 
-//
-// STY OpCodes
-//
+uint8_t BVSInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// TAX OpCodes
+// SEI
 //
 
-//
-// TAY OpCodes
-//
+uint8_t SEIInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// TSX OpCodes
+// STA
 //
 
-//
-// TXA OpCodes
-//
+uint8_t STAInstruction::IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t STAInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t STAInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t STAInstruction::IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t STAInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t STAInstruction::ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t STAInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 //
-// TXS OpCodes
+// STY
 //
 
+uint8_t STYInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t STYInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t STYInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
 //
-// TYA OpCodes
+// STX
 //
 
+uint8_t STXInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t STXInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t STXInstruction::ZPY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// DEY
+//
+
+uint8_t DEYInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// TXA
+//
+
+uint8_t TXAInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// BCC
+//
+
+uint8_t BCCInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// TYA
+//
+
+uint8_t TYAInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// TXS
+//
+
+uint8_t TXSInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// LDY
+//
+
+uint8_t LDYInstruction::IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t LDYInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t LDYInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t LDYInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t LDYInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// LDA
+//
+
+uint8_t LDAInstruction::IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t LDAInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t LDAInstruction::IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t LDAInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t LDAInstruction::IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t LDAInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t LDAInstruction::ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t LDAInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// LDX
+//
+
+uint8_t LDXInstruction::IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t LDXInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t LDXInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t LDXInstruction::ZPY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t LDXInstruction::ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// TAY
+//
+
+uint8_t TAYInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// TAX
+//
+
+uint8_t TAXInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// BCS
+//
+
+uint8_t BCSInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// CLV
+//
+
+uint8_t CLVInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// TSX
+//
+
+uint8_t TSXInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// CPY
+//
+
+uint8_t CPYInstruction::IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t CPYInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t CPYInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// CMP
+//
+
+uint8_t CMPInstruction::IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t CMPInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t CMPInstruction::IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t CMPInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t CMPInstruction::IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t CMPInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t CMPInstruction::ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t CMPInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// DEC
+//
+
+uint8_t DECInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t DECInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t DECInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t DECInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// INY
+//
+
+uint8_t INYInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// DEX
+//
+
+uint8_t DEXInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// BNE
+//
+
+uint8_t BNEInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// CLD
+//
+
+uint8_t CLDInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// CPX
+//
+
+uint8_t CPXInstruction::IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t CPXInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t CPXInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// SBC
+//
+
+uint8_t SBCInstruction::IINDX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t SBCInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t SBCInstruction::IMM(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t SBCInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t SBCInstruction::IINDY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t SBCInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t SBCInstruction::ABSY(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t SBCInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// INC
+//
+
+uint8_t INCInstruction::ZP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t INCInstruction::ABS(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t INCInstruction::ZPX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+uint8_t INCInstruction::ABSX(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// INX
+//
+
+uint8_t INXInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// NOP
+//
+
+uint8_t NOPInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// BEQ
+//
+
+uint8_t BEQInstruction::REL(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
+
+//
+// SED
+//
+
+uint8_t SEDInstruction::IMP(nes::cpu::Registers& registers, nes::cpu::bus::IBus& bus) { return 0; }       
 
 }

--- a/lib/nes/src/nes/cpu/instructions/instructionset.cpp
+++ b/lib/nes/src/nes/cpu/instructions/instructionset.cpp
@@ -78,7 +78,32 @@ InstructionSet::InstructionSet(IInstructionErrorHandler& handler)
         &_cpx, &_sbc, &_unk, &_unk, &_cpx, &_sbc, &_inc, &_unk, &_inx, &_sbc, &_nop, &_unk, &_cpx, &_sbc, &_inc, &_unk, 
         &_beq, &_sbc, &_unk, &_unk, &_unk, &_sbc, &_inc, &_unk, &_sed, &_sbc, &_unk, &_unk, &_unk, &_sbc, &_inc, &_unk, 
     }
+    , _addressingModeMatrix{
+        AddressingMode::IMP, AddressingMode::IINDX, AddressingMode::UNK,  AddressingMode::UNK, AddressingMode::ZP,  AddressingMode::ZP,  AddressingMode::ZP,  AddressingMode::ZP, AddressingMode::IMP, AddressingMode::IMM,  AddressingMode::ACC, AddressingMode::UNK, AddressingMode::ABS,   AddressingMode::ABS,  AddressingMode::ABS,  AddressingMode::ZP,              
+        AddressingMode::REL, AddressingMode::IINDY, AddressingMode::IIND, AddressingMode::UNK, AddressingMode::ZP,  AddressingMode::ZPX, AddressingMode::ZPX, AddressingMode::ZP, AddressingMode::IMP, AddressingMode::ABSY, AddressingMode::ACC, AddressingMode::UNK, AddressingMode::ABS,   AddressingMode::ABSX, AddressingMode::ABSX, AddressingMode::ZP,              
+        AddressingMode::ABS, AddressingMode::IINDX, AddressingMode::UNK,  AddressingMode::UNK, AddressingMode::ZP,  AddressingMode::ZP,  AddressingMode::ZP,  AddressingMode::ZP, AddressingMode::IMP, AddressingMode::IMM,  AddressingMode::ACC, AddressingMode::UNK, AddressingMode::ABS,   AddressingMode::ABS,  AddressingMode::ABS,  AddressingMode::ZP,              
+        AddressingMode::REL, AddressingMode::IINDY, AddressingMode::IIND, AddressingMode::UNK, AddressingMode::ZPX, AddressingMode::ZPX, AddressingMode::ZPX, AddressingMode::ZP, AddressingMode::IMP, AddressingMode::ABSY, AddressingMode::ACC, AddressingMode::UNK, AddressingMode::ABSX,  AddressingMode::ABSX, AddressingMode::ABSX, AddressingMode::ZP,              
+        AddressingMode::IMP, AddressingMode::IINDX, AddressingMode::UNK,  AddressingMode::UNK, AddressingMode::UNK, AddressingMode::ZP,  AddressingMode::ZP,  AddressingMode::ZP, AddressingMode::IMP, AddressingMode::IMM,  AddressingMode::ACC, AddressingMode::UNK, AddressingMode::ABS,   AddressingMode::ABS,  AddressingMode::ABS,  AddressingMode::ZP,              
+        AddressingMode::REL, AddressingMode::IINDY, AddressingMode::IIND, AddressingMode::UNK, AddressingMode::UNK, AddressingMode::ZPX, AddressingMode::ZPX, AddressingMode::ZP, AddressingMode::IMP, AddressingMode::ABSY, AddressingMode::IMP, AddressingMode::UNK, AddressingMode::UNK,   AddressingMode::ABSX, AddressingMode::ABSX, AddressingMode::ZP,              
+        AddressingMode::IMP, AddressingMode::IINDX, AddressingMode::UNK,  AddressingMode::UNK, AddressingMode::ZP,  AddressingMode::ZP,  AddressingMode::ZP,  AddressingMode::ZP, AddressingMode::IMP, AddressingMode::IMM,  AddressingMode::ACC, AddressingMode::UNK, AddressingMode::IABS,  AddressingMode::ABS,  AddressingMode::ABS,  AddressingMode::ZP,              
+        AddressingMode::REL, AddressingMode::IINDY, AddressingMode::IIND, AddressingMode::UNK, AddressingMode::ZPX, AddressingMode::ZPX, AddressingMode::ZPX, AddressingMode::ZP, AddressingMode::IMP, AddressingMode::ABSY, AddressingMode::IMP, AddressingMode::UNK, AddressingMode::IABSX, AddressingMode::ABSX, AddressingMode::ABSX, AddressingMode::ZP,              
+        AddressingMode::REL, AddressingMode::IINDX, AddressingMode::UNK,  AddressingMode::UNK, AddressingMode::ZP,  AddressingMode::ZP,  AddressingMode::ZP,  AddressingMode::ZP, AddressingMode::IMP, AddressingMode::IMM,  AddressingMode::IMP, AddressingMode::UNK, AddressingMode::ABS,   AddressingMode::ABS,  AddressingMode::ABS,  AddressingMode::ZP,              
+        AddressingMode::REL, AddressingMode::IINDY, AddressingMode::IIND, AddressingMode::UNK, AddressingMode::ZPX, AddressingMode::ZPX, AddressingMode::ZPY, AddressingMode::ZP, AddressingMode::IMP, AddressingMode::ABSY, AddressingMode::IMP, AddressingMode::UNK, AddressingMode::ABS,   AddressingMode::ABSX, AddressingMode::ABSX, AddressingMode::ZP,              
+        AddressingMode::IMM, AddressingMode::IINDX, AddressingMode::IMM,  AddressingMode::UNK, AddressingMode::ZP,  AddressingMode::ZP,  AddressingMode::ZP,  AddressingMode::ZP, AddressingMode::IMP, AddressingMode::IMM,  AddressingMode::IMP, AddressingMode::UNK, AddressingMode::ABS,   AddressingMode::ABS,  AddressingMode::ABS,  AddressingMode::ZP,              
+        AddressingMode::REL, AddressingMode::IINDY, AddressingMode::IIND, AddressingMode::UNK, AddressingMode::ZPX, AddressingMode::ZPX, AddressingMode::ZPY, AddressingMode::ZP, AddressingMode::IMP, AddressingMode::ABSY, AddressingMode::IMP, AddressingMode::UNK, AddressingMode::ABSX,  AddressingMode::ABSX, AddressingMode::ABSY, AddressingMode::ZP,              
+        AddressingMode::IMM, AddressingMode::IINDX, AddressingMode::UNK,  AddressingMode::UNK, AddressingMode::ZP,  AddressingMode::ZP,  AddressingMode::ZP,  AddressingMode::ZP, AddressingMode::IMP, AddressingMode::IMM,  AddressingMode::IMP, AddressingMode::UNK, AddressingMode::ABS,   AddressingMode::ABS,  AddressingMode::ABS,  AddressingMode::ZP,              
+        AddressingMode::REL, AddressingMode::IINDY, AddressingMode::IIND, AddressingMode::UNK, AddressingMode::UNK, AddressingMode::ZPX, AddressingMode::ZPX, AddressingMode::ZP, AddressingMode::IMP, AddressingMode::ABSY, AddressingMode::IMP, AddressingMode::UNK, AddressingMode::UNK,   AddressingMode::ABSX, AddressingMode::ABSX, AddressingMode::ZP,              
+        AddressingMode::IMM, AddressingMode::IINDX, AddressingMode::UNK,  AddressingMode::UNK, AddressingMode::ZP,  AddressingMode::ZP,  AddressingMode::ZP,  AddressingMode::ZP, AddressingMode::IMP, AddressingMode::IMM,  AddressingMode::IMP, AddressingMode::UNK, AddressingMode::ABS,   AddressingMode::ABS,  AddressingMode::ABS,  AddressingMode::ZP,              
+        AddressingMode::REL, AddressingMode::IINDY, AddressingMode::IIND, AddressingMode::UNK, AddressingMode::UNK, AddressingMode::ZPX, AddressingMode::ZPX, AddressingMode::ZP, AddressingMode::IMP, AddressingMode::ABSY, AddressingMode::IMP, AddressingMode::UNK, AddressingMode::UNK,   AddressingMode::ABSX, AddressingMode::ABSX, AddressingMode::ZP,              
+    }
 {
+}
+
+IInstruction& InstructionSet::get(const uint8_t index)
+{
+    auto* instruction = _instructionMatrix[index];
+    instruction->setMode(_addressingModeMatrix[index]);
+    return *instruction;
 }
 
 }

--- a/lib/nes/src/nes/cpu/instructions/instructionset.cpp
+++ b/lib/nes/src/nes/cpu/instructions/instructionset.cpp
@@ -1,0 +1,84 @@
+#include <nes/cpu/instructions/instructionset.h>
+
+namespace nes::cpu::instructions
+{
+InstructionSet::InstructionSet(IInstructionErrorHandler& handler)
+    : _adc(handler)
+    , _and(handler)
+    , _asl(handler)
+    , _bcc(handler)
+    , _bcs(handler)
+    , _beq(handler)
+    , _bit(handler)
+    , _bmi(handler)
+    , _bne(handler)
+    , _bpl(handler)
+    , _brk(handler)
+    , _bvc(handler)
+    , _bvs(handler)
+    , _clc(handler)
+    , _cld(handler)
+    , _cli(handler)
+    , _clv(handler)
+    , _cmp(handler)
+    , _cpx(handler)
+    , _cpy(handler)
+    , _dec(handler)
+    , _dex(handler)
+    , _dey(handler)
+    , _eor(handler)
+    , _inc(handler)
+    , _inx(handler)
+    , _iny(handler)
+    , _jmp(handler)
+    , _jsr(handler)
+    , _lda(handler)
+    , _ldx(handler)
+    , _ldy(handler)
+    , _lsr(handler)
+    , _nop(handler)
+    , _ora(handler)
+    , _pha(handler)
+    , _php(handler)
+    , _pla(handler)
+    , _plp(handler)
+    , _rol(handler)
+    , _ror(handler)
+    , _rti(handler)
+    , _rts(handler)
+    , _sbc(handler)
+    , _sec(handler)
+    , _sed(handler)
+    , _sei(handler)
+    , _sta(handler)
+    , _stx(handler)
+    , _sty(handler)
+    , _tax(handler)
+    , _tay(handler)
+    , _tsx(handler)
+    , _txa(handler)
+    , _txs(handler)
+    , _tya(handler)
+    , _unk("XXX", handler)
+    , _instructionMatrix{
+        &_brk, &_ora, &_unk, &_unk, &_unk, &_ora, &_asl, &_unk, &_php, &_ora, &_asl, &_unk, &_unk, &_ora, &_asl, &_unk,
+        &_bpl, &_ora, &_unk, &_unk, &_unk, &_ora, &_asl, &_unk, &_clc, &_ora, &_unk, &_unk, &_unk, &_ora, &_asl, &_unk,
+        &_jsr, &_and, &_unk, &_unk, &_bit, &_and, &_rol, &_unk, &_plp, &_and, &_rol, &_unk, &_bit, &_and, &_rol, &_unk, 
+        &_bmi, &_and, &_unk, &_unk, &_unk, &_and, &_rol, &_unk, &_sec, &_and, &_unk, &_unk, &_unk, &_and, &_rol, &_unk, 
+        &_rti, &_eor, &_unk, &_unk, &_unk, &_eor, &_lsr, &_unk, &_pha, &_eor, &_lsr, &_unk, &_jmp, &_eor, &_lsr, &_unk, 
+        &_bvc, &_eor, &_unk, &_unk, &_unk, &_eor, &_lsr, &_unk, &_cli, &_eor, &_unk, &_unk, &_unk, &_eor, &_lsr, &_unk, 
+        &_rts, &_adc, &_unk, &_unk, &_unk, &_adc, &_ror, &_unk, &_pla, &_adc, &_ror, &_unk, &_jmp, &_adc, &_ror, &_unk, 
+        &_bvs, &_adc, &_unk, &_unk, &_unk, &_adc, &_ror, &_unk, &_sei, &_adc, &_unk, &_unk, &_unk, &_adc, &_ror, &_unk, 
+        &_unk, &_sta, &_unk, &_unk, &_sty, &_sta, &_stx, &_unk, &_dey, &_unk, &_txa, &_unk, &_sty, &_sta, &_stx, &_unk, 
+        &_bcc, &_sta, &_unk, &_unk, &_sty, &_sta, &_stx, &_unk, &_tya, &_sta, &_txs, &_unk, &_unk, &_sta, &_unk, &_unk, 
+        &_ldy, &_lda, &_ldx, &_unk, &_ldy, &_lda, &_ldx, &_unk, &_tay, &_lda, &_tax, &_unk, &_ldy, &_lda, &_ldx, &_unk, 
+        &_bcs, &_lda, &_unk, &_unk, &_ldy, &_lda, &_ldx, &_unk, &_clv, &_lda, &_tsx, &_unk, &_ldy, &_lda, &_ldx, &_unk, 
+        &_cpy, &_cmp, &_unk, &_unk, &_cpy, &_cmp, &_dec, &_unk, &_iny, &_cmp, &_dex, &_unk, &_cpy, &_cmp, &_dec, &_unk, 
+        &_bne, &_cmp, &_unk, &_unk, &_unk, &_cmp, &_dec, &_unk, &_cld, &_cmp, &_unk, &_unk, &_unk, &_cmp, &_dec, &_unk, 
+        &_cpx, &_sbc, &_unk, &_unk, &_cpx, &_sbc, &_inc, &_unk, &_inx, &_sbc, &_nop, &_unk, &_cpx, &_sbc, &_inc, &_unk, 
+        &_beq, &_sbc, &_unk, &_unk, &_unk, &_sbc, &_inc, &_unk, &_sed, &_sbc, &_unk, &_unk, &_unk, &_sbc, &_inc, &_unk, 
+    }
+{
+}
+
+}

--- a/lib/nes/tests/CMakeLists.txt
+++ b/lib/nes/tests/CMakeLists.txt
@@ -3,7 +3,6 @@ include(../../../GoogleTest.cmake)
 
 function(add_test_executable filename lib) # add source files after test file, they will be added automatically
     get_filename_component(testname ${filename} NAME_WE)
-    message("file noext ${testname}")
     add_executable(${testname} ${filename})
 
     target_link_libraries(${testname} PRIVATE ${GMOCK_MAIN_PATH})

--- a/lib/nes/tests/CMakeLists.txt
+++ b/lib/nes/tests/CMakeLists.txt
@@ -15,3 +15,5 @@ endfunction()
 
 add_test_executable(bus-tests.cpp nes-bus-lib)
 add_test_executable(memory-tests.cpp nes-peripheral-memory-lib)
+add_test_executable(instruction-decoder-tests.cpp nes-instruction-decoder-lib)
+add_test_executable(instruction-tests.cpp nes-instructions-lib)

--- a/lib/nes/tests/bus-tests.cpp
+++ b/lib/nes/tests/bus-tests.cpp
@@ -1,16 +1,16 @@
 #include <gtest/gtest.h>
 #include <vector>
 
-#include <nes/bus/bus.h>
+#include <nes/cpu/bus/bus.h>
 
 class BusTestFixture : public testing::Test
 {
 protected:
-    nes::bus::IBus* bus;
+    nes::cpu::bus::IBus* bus;
     
     void SetUp() override
     {
-        bus = new nes::bus::Bus;
+        bus = new nes::cpu::bus::Bus;
     }
 
     void TearDown() override

--- a/lib/nes/tests/instruction-decoder-tests.cpp
+++ b/lib/nes/tests/instruction-decoder-tests.cpp
@@ -1,0 +1,3 @@
+#include <gtest/gtest.h>
+#include <nes/cpu/instructions/instruction_decoder.h>
+

--- a/lib/nes/tests/instruction-tests.cpp
+++ b/lib/nes/tests/instruction-tests.cpp
@@ -2036,11 +2036,6 @@ TEST_F(InstructionTestFixture, PLATest)
     run<PLAInstruction>(AddressingMode::IMP, 4, expected);
 }
 
-TEST_F(InstructionTestFixture, BVSTest)
-{
-    FAIL() << "Not yet implemented";
-}
-
 TEST_F(InstructionTestFixture, SEITest)
 {
     auto expected = registers;
@@ -2185,11 +2180,6 @@ TEST_F(InstructionTestFixture, TXATest)
     expected.p.z = false;
     expected.p.n = true;
     run<TXAInstruction>(AddressingMode::IMP, 2, expected);
-}
-
-TEST_F(InstructionTestFixture, BCCTest)
-{
-    FAIL() << "Not yet implemented";
 }
 
 TEST_F(InstructionTestFixture, TYATest)
@@ -2448,11 +2438,6 @@ TEST_F(InstructionTestFixture, TAXTest)
     expected.p.n = false;
     expected.p.z = true;
     run<TAXInstruction>(AddressingMode::IMP, 2, expected);
-}
-
-TEST_F(InstructionTestFixture, BCSTest)
-{
-    FAIL() << "Not yet implemented";
 }
 
 TEST_F(InstructionTestFixture, CLVTest)
@@ -3110,9 +3095,104 @@ TEST_F(InstructionTestFixture, DEXTest)
     run<DEXInstruction>(AddressingMode::IMP, 2, expected);
 }
 
+TEST_F(InstructionTestFixture, BEQTest)
+{
+    load(0xFF00, {5});
+    auto expected = registers;
+    expected.p.z = false;
+    expected.pc += 2;
+    run<BEQInstruction>(AddressingMode::REL, 2, expected);
+
+    load(0xFF00, {5});
+    registers.p.z = true;
+    expected = registers;
+    expected.pc = 0xFF05;
+    run<BEQInstruction>(AddressingMode::REL, 3, expected);
+
+    load(0xFF00, {(uint8_t)-1});
+    expected = registers;
+    expected.pc = 0xFEFF;
+    run<BEQInstruction>(AddressingMode::REL, 4, expected);
+}
+
 TEST_F(InstructionTestFixture, BNETest)
 {
-    FAIL() << "Not yet implemented";
+    load(0xFF00, {5});
+    registers.p.z = true;
+    auto expected = registers;
+    expected.pc += 2;
+    run<BNEInstruction>(AddressingMode::REL, 2, expected);
+
+    load(0xFF00, {5});
+    registers.p.z = false;
+    expected = registers;
+    expected.pc = 0xFF05;
+    run<BNEInstruction>(AddressingMode::REL, 3, expected);
+
+    load(0xFF00, {(uint8_t)-1});
+    expected = registers;
+    expected.pc = 0xFEFF;
+    run<BNEInstruction>(AddressingMode::REL, 4, expected);
+}
+
+TEST_F(InstructionTestFixture, BCCTest)
+{
+    load(0xFF00, {5});
+    registers.p.c = true;
+    auto expected = registers;
+    expected.pc += 2;
+    run<BCCInstruction>(AddressingMode::REL, 2, expected);
+
+    load(0xFF00, {5});
+    registers.p.c = false;
+    expected = registers;
+    expected.pc = 0xFF05;
+    run<BCCInstruction>(AddressingMode::REL, 3, expected);
+
+    load(0xFF00, {(uint8_t)-1});
+    expected = registers;
+    expected.pc = 0xFEFF;
+    run<BCCInstruction>(AddressingMode::REL, 4, expected);
+}
+
+TEST_F(InstructionTestFixture, BCSTest)
+{
+    load(0xFF00, {5});
+    auto expected = registers;
+    expected.p.c = false;
+    expected.pc += 2;
+    run<BCSInstruction>(AddressingMode::REL, 2, expected);
+
+    load(0xFF00, {5});
+    registers.p.c = true;
+    expected = registers;
+    expected.pc = 0xFF05;
+    run<BCSInstruction>(AddressingMode::REL, 3, expected);
+
+    load(0xFF00, {(uint8_t)-1});
+    expected = registers;
+    expected.pc = 0xFEFF;
+    run<BCSInstruction>(AddressingMode::REL, 4, expected);
+}
+
+TEST_F(InstructionTestFixture, BVSTest)
+{
+    load(0xFF00, {5});
+    registers.p.v = false;
+    auto expected = registers;
+    expected.pc += 2;
+    run<BVSInstruction>(AddressingMode::REL, 2, expected);
+
+    load(0xFF00, {5});
+    registers.p.v = true;
+    expected = registers;
+    expected.pc = 0xFF05;
+    run<BVSInstruction>(AddressingMode::REL, 3, expected);
+
+    load(0xFF00, {(uint8_t)-1});
+    expected = registers;
+    expected.pc = 0xFEFF;
+    run<BVSInstruction>(AddressingMode::REL, 4, expected);
 }
 
 TEST_F(InstructionTestFixture, INCZeroPageTest)
@@ -3223,11 +3303,6 @@ TEST_F(InstructionTestFixture, INXTest)
     expected.p.z = true;
     expected.pc++;
     run<INXInstruction>(AddressingMode::IMP, 2, expected);
-}
-
-TEST_F(InstructionTestFixture, BEQTest)
-{
-    FAIL() << "Not yet implemented";
 }
 
 TEST_F(InstructionTestFixture, SEDTest)

--- a/lib/nes/tests/instruction-tests.cpp
+++ b/lib/nes/tests/instruction-tests.cpp
@@ -1,0 +1,61 @@
+#include <gtest/gtest.h>
+#include <nes/cpu/instructions/iinstruction_error_handler.h>
+#include <nes/cpu/instructions/instructions.h>
+#include <nes/cpu/bus/ibus.h>
+#include <nes/cpu/registers.h>
+#include <vector>
+
+using namespace nes::cpu::instructions;
+
+// Definition of mock types
+
+class MockInstructionErrorHandler : public IInstructionErrorHandler
+{
+private:
+    bool _raised;
+    AddressingMode _mode;
+public:
+    virtual void invalidMode(IInstruction& instruction, AddressingMode mode) override { _raised = true; _mode = mode; }
+    void reset()                { _raised = false; }
+    bool raised() const         { return _raised;  }
+    AddressingMode mode() const { return _mode;    }
+};
+
+class MockBus : public nes::cpu::bus::IBus
+{
+private:
+    std::vector<uint8_t> _memory;
+public:
+    MockBus(int size) : _memory(size)                                  { _memory.reserve(size); for(int i = 0; i < size; i++) _memory[i] = 0; }
+    virtual uint8_t read(uint16_t address) const                       { return _memory[address];  }
+    virtual void    write(uint16_t address, uint8_t value)             { _memory[address] = value; }
+    virtual void    connect(nes::peripherals::IPeripheral& peripheral) { /* not used */            }
+};
+
+// Definition of test fixture
+
+class InstructionTestFixture : public testing::Test
+{
+protected:
+    MockInstructionErrorHandler* handler;
+    MockBus* bus;
+    void SetUp() override
+    {
+        handler = new MockInstructionErrorHandler;
+        bus = new MockBus(100);
+    }
+
+    void TearDown() override
+    {
+        delete handler;
+        delete bus;
+
+        handler = nullptr;
+        bus     = nullptr;
+    }
+};
+
+TEST_F(InstructionTestFixture, NOPTest)
+{
+    ASSERT_EQ(1, 1);
+}

--- a/lib/nes/tests/instruction-tests.cpp
+++ b/lib/nes/tests/instruction-tests.cpp
@@ -4,8 +4,13 @@
 #include <nes/cpu/bus/ibus.h>
 #include <nes/cpu/registers.h>
 #include <vector>
+#include <nes/cpu/instructions/instructionset.h>
+
+
+
 
 using namespace nes::cpu::instructions;
+using namespace nes::cpu;
 
 // Definition of mock types
 
@@ -39,10 +44,13 @@ class InstructionTestFixture : public testing::Test
 protected:
     MockInstructionErrorHandler* handler;
     MockBus* bus;
+    nes::cpu::Registers registers;
     void SetUp() override
     {
         handler = new MockInstructionErrorHandler;
-        bus = new MockBus(100);
+        bus     = new MockBus(100);
+
+        registers.reset();
     }
 
     void TearDown() override
@@ -55,7 +63,325 @@ protected:
     }
 };
 
+
+
+// based on information found here: http://www.obelisk.me.uk/6502/reference.html
+
 TEST_F(InstructionTestFixture, NOPTest)
 {
-    ASSERT_EQ(1, 1);
+    NOPInstruction instruction(*handler);
+    instruction.setMode(AddressingMode::IMP);
+
+    auto expected = registers;
+    expected.pc++;
+    auto ticks = instruction.execute(registers, *bus);
+
+    ASSERT_EQ(1, ticks);
+    ASSERT_EQ(expected, registers);
+    ASSERT_FALSE(handler->raised());
+    
+}
+
+TEST_F(InstructionTestFixture, CLCTest)
+{
+    CLCInstruction instruction(*handler);
+    instruction.setMode(AddressingMode::IMP);
+
+    registers.p.c = true;
+    auto expected = registers;
+    expected.pc++;
+    expected.p.c = false;
+    
+    auto ticks = instruction.execute(registers, *bus);
+
+    ASSERT_EQ(2, ticks);
+    ASSERT_EQ(expected, registers);
+    ASSERT_FALSE(handler->raised());
+}
+
+TEST_F(InstructionTestFixture, CLDTest)
+{
+    CLDInstruction instruction(*handler);
+    instruction.setMode(AddressingMode::IMP);
+
+    registers.p.d = true;
+    auto expected = registers;
+    expected.pc++;
+    expected.p.d = false;
+    
+    auto ticks = instruction.execute(registers, *bus);
+
+    ASSERT_EQ(2, ticks);
+    ASSERT_EQ(expected, registers);
+    ASSERT_FALSE(handler->raised());
+}
+
+TEST_F(InstructionTestFixture, BRKTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, ORATest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, XXXTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, ASLTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, PHPTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, BPLTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, JSRTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, ANDTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, BITTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, ROLTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, PLPTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, BMITest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, SECTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, RTITest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, EORTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, LSRTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, PHATest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, JMPTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, BVCTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, CLITest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, RTSTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, ADCTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, RORTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, PLATest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, BVSTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, SEITest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, STATest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, STYTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, STXTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, DEYTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, TXATest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, BCCTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, TYATest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, TXSTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, LDYTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, LDATest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, LDXTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, TAYTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, TAXTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, BCSTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, CLVTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, TSXTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, CPYTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, CMPTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, DECTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, INYTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, DEXTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, BNETest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, CPXTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, SBCTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, INCTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, INXTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, BEQTest)
+{
+    FAIL() << "Not yet implemented";
+}
+
+TEST_F(InstructionTestFixture, SEDTest)
+{
+    FAIL() << "Not yet implemented";
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,7 @@
 #include <iostream>
-#include <nes/peripherals/memory.h>
 
 int main(int argc, char** argv)
 {
-
     for(int i = 0; i < argc; i++)
     {
         std::cout << argv[i] << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <nes/cpu/instructions/instructions.h>
 
 int main(int argc, char** argv)
 {


### PR DESCRIPTION
Added all standard instructions for the NMOS 6502. The newer instructions are not used by the NES because these are only implemented in CMOS variants.

Also skipped on decimal mode and its quirks as that mode is also not supported by the NES.